### PR TITLE
fix/pr template not working on github

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# [Related Task]()
+
+## Link for [Demo]()
+
+- (Optional) Link for [Figma]()
+- (Optional) Other [Resources]()
+
+## Why do you do this PR
+
+-
+
+## What did you do
+
+-
+
+## Checklist
+
+- [ ] Merged this PR into [dev](https://github.com/thinc-org/cugetreg-frontend/tree/dev) for Demo
+- [ ] Wrote coverage tests
+
+## Browser Supported
+
+- [x] Safari
+- [x] Google Chrome
+- [x] Firefox
+- [x] Microsoft Edge
+
+## Other thing to tell us
+
+-


### PR DESCRIPTION
# Related Task: -

## Link for Demo: Can only demo on default branch (beta)

## Why do you do this PR

- Pull request template not working

## What did you do

- Move pr-template file to outer directory to work per [Gabriel Caruso's suggestions](https://stackoverflow.com/questions/52139192/github-pull-requests-template-not-showing/52139815)

## Checklist

- [x] Merged this PR into [dev](https://github.com/thinc-org/cugetreg-frontend/tree/dev) for Demo
- [x] Wrote coverage tests

## Browser Supported

- [x] Safari
- [x] Google Chrome
- [x] Firefox
- [x] Microsoft Edge

## Other thing to tell us

-
