### PR TITLE
fix/apollo cache not working as intended in #229

### DIFF
--- a/src/modules/CourseSearch/context/CourseSearch/hooks/useCourseSearchProvider/index.tsx
+++ b/src/modules/CourseSearch/context/CourseSearch/hooks/useCourseSearchProvider/index.tsx
@@ -26,11 +26,6 @@ export const useCourseSearchProvider = () => {
     },
   })
 
-  useEffect(() => {
-    courseSearchQuery.refetch()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchCourseQueryParams.filter.periodRange?.start, searchCourseQueryParams.filter.periodRange?.end])
-
   const fetchMoreCourses = async () => {
     if (!courseSearchQuery.loading && !isEmpty) {
       const result = await courseSearchQuery.fetchMore({

--- a/src/services/apollo/index.ts
+++ b/src/services/apollo/index.ts
@@ -23,6 +23,7 @@ const cache = new InMemoryCache({
             const filter = a.filter
             hash += ':' + (filter.dayOfWeeks ? JSON.stringify(filter.dayOfWeeks) : '')
             hash += ':' + (filter.genEdTypes ? JSON.stringify(filter.genEdTypes) : '')
+            hash += ':' + (filter.periodRange ? JSON.stringify(filter.periodRange) : '')
             hash += ':' + (filter.keyword || '')
             return hash
           },


### PR DESCRIPTION
# [Related Task]()

## Link for [Demo on dev](https://dev.cugetreg.com/S/courses)

## Why do you do this PR

To reproduce bug
1. go to https://beta.cugetreg.com
2. Click on `หมวดวิทย์`
3. Click on `เวลาเรียน`
4. Select `22:00 - 22:00`
5. Deselect `หมวดวิทย์`

Expected result: only `3503570 APPLIED MUSIC IV` (Only subject that matched with `22:00 - 22:00` filter)
Actual result: `0123104 UNIV THAI READING`, `0201122 MGT PUB DISASTER`.... (Default search result without `เวลาเรียน` filter)

## What did you do

- Remove refetch logic and use apollo cahce hashing mechanism instead

## Checklist

- [x] Merged this PR into [dev](https://github.com/thinc-org/cugetreg-frontend/tree/dev) for Demo
- [ ] Wrote coverage tests

## Browser Supported

- [x] Safari
- [x] Google Chrome
- [x] Firefox
- [x] Microsoft Edge

## Other thing to tell us

-
