### PR TITLE
Add padding below sticky filter section

### DIFF
--- a/src/modules/CourseSearch/components/FilterSection/styled.tsx
+++ b/src/modules/CourseSearch/components/FilterSection/styled.tsx
@@ -27,7 +27,7 @@ export const StickyPaper = styled(Paper)<{ hasTags: boolean }>`
   width: fit-content;
   height: fit-content;
   top: ${({ hasTags }) => (hasTags ? '125px' : '101px')};
-  max-height: calc(100vh - ${({ hasTags }) => (hasTags ? '125px' : '101px')});
+  max-height: calc(100vh - ${({ hasTags }) => (hasTags ? '125px' : '101px')} - 24px);
 `
 
 export const Button = styled(MuiButton)`


### PR DESCRIPTION
# [Related Task]()

## Link for [Demo]()

- (Optional) Link for [Figma]()
- (Optional) Other [Resources]()

## Why do you do this PR

<img width="355" alt="Screen Shot 2564-11-04 at 11 53 56" src="https://user-images.githubusercontent.com/8080853/140260028-09932341-70ad-460d-a407-7b9573ec2bc8.png">


## What did you do

<img width="329" alt="Screen Shot 2564-11-04 at 11 54 13" src="https://user-images.githubusercontent.com/8080853/140260052-7cebc053-fddf-4b42-bdd0-f93b4169a1ac.png">


## Checklist

- [x] Merged this PR into [dev](https://github.com/thinc-org/cugetreg-frontend/tree/dev) for Demo
- [ ] Wrote coverage tests

## Browser Supported

- [x] Safari
- [x] Google Chrome
- [x] Firefox
- [x] Microsoft Edge

## Other thing to tell us

-
