### PR TITLE
Don't run release job unless on master

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -24,6 +24,7 @@ env:
 jobs:
   release-note:
     name: Release
+    if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,7 +43,6 @@ jobs:
         run: yarn --fronzen-lockfile
 
       - name: Release
-        if: ${{ github.ref == 'refs/heads/master' }}
         run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# [Related Task]()

## Link for [Demo](https://github.com/thinc-org/cugetreg-frontend/actions/runs/1426208557)

- (Optional) Link for [Figma]()
- (Optional) Other [Resources]()

## Why do you do this PR

- The release job is always run regardless of the branch, wasting 37 seconds
<img width="689" alt="Screen Shot 2564-11-05 at 22 01 37" src="https://user-images.githubusercontent.com/8080853/140531829-0b6c6d15-9fac-41c2-9ed3-05a3dac40833.png">


## What did you do

- Got rid of it on all branches except master

## Checklist

- [x] Merged this PR into [dev](https://github.com/thinc-org/cugetreg-frontend/tree/dev) for Demo
- [ ] Wrote coverage tests

## Browser Supported

- [x] Safari
- [x] Google Chrome
- [x] Firefox
- [x] Microsoft Edge

## Other thing to tell us

-
