### PR TITLE
Fix release note configuration

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -79,7 +79,7 @@ const noteTransform = (commit, context) => {
 // Release Configuration For [semantic-release](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration)
 
 module.exports = {
-  branches: [{ name: 'main' }],
+  branches: [{ name: 'master' }],
   plugins: [
     '@semantic-release/commit-analyzer',
     [

--- a/release.config.js
+++ b/release.config.js
@@ -1,20 +1,104 @@
+const noteTransform = (commit, context) => {
+  let discard = true
+  const issues = []
+
+  // For debugging
+  // console.log('commit', commit)
+
+  commit.notes.forEach((note) => {
+    note.title = 'BREAKING CHANGES'
+    discard = false
+  })
+
+  if (commit.type === 'feat') {
+    commit.type = 'Features'
+  } else if (commit.type === 'fix') {
+    commit.type = 'Bug Fixes'
+  } else if (commit.type === 'perf') {
+    commit.type = 'Performance Improvements'
+  } else if (commit.type === 'revert' || commit.revert) {
+    commit.type = 'Reverts'
+  } else if (discard) {
+    return
+  } else if (commit.type === 'docs') {
+    commit.type = 'Documentation'
+  } else if (commit.type === 'style') {
+    commit.type = 'Styles'
+  } else if (commit.type === 'refactor') {
+    commit.type = 'Code Refactoring'
+  } else if (commit.type === 'test') {
+    commit.type = 'Tests'
+  } else if (commit.type === 'build') {
+    commit.type = 'Build System'
+  } else if (commit.type === 'ci') {
+    commit.type = 'Continuous Integration'
+  }
+
+  if (commit.scope === '*') {
+    commit.scope = ''
+  }
+
+  if (typeof commit.hash === 'string') {
+    commit.shortHash = commit.hash.substring(0, 7)
+  }
+
+  if (typeof commit.subject === 'string') {
+    let url = context.repository
+      ? `${context.host}/${context.owner}/${context.repository}`
+      : context.repoUrl
+    if (url) {
+      url = `${url}/issues/`
+      // Issue URLs.
+      commit.subject = commit.subject.replace(/#([0-9]+)/g, (_, issue) => {
+        issues.push(issue)
+        return `[#${issue}](${url}${issue})`
+      })
+    }
+    if (context.host) {
+      // User URLs.
+      commit.subject = commit.subject.replace(
+        /\B@([a-z0-9](?:-?[a-z0-9/]){0,38})/g,
+        (_, username) => {
+          if (username.includes('/')) {
+            return `@${username}`
+          }
+
+          return `[@${username}](${context.host}/${username})`
+        }
+      )
+    }
+  }
+
+  // remove references that already appear in the subject
+  commit.references = commit.references.filter((reference) => {
+    return issues.indexOf(reference.issue) === -1
+  })
+
+  return commit
+}
+
 // Release Configuration For [semantic-release](https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#configuration)
+
 module.exports = {
-  branches: [{ name: 'master' }],
+  branches: [{ name: 'main' }],
   plugins: [
-    [
-      '@semantic-release/commit-analyzer',
-      {
-        preset: 'angular',
-        parserOpts: { noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES', 'BREAKING'] },
-      },
-    ],
+    '@semantic-release/commit-analyzer',
     [
       '@semantic-release/release-notes-generator',
       {
         preset: 'angular',
-        parserOpts: { noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES', 'BREAKING'] },
-        writerOpts: { commitsSort: ['subject', 'scope'] },
+        parserOpts: {
+          mergePattern: /^Merge pull request #(\d+) from (.*)$/,
+          mergeCorrespondence: ['mergeId', 'source'],
+          noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES', 'BREAKING'],
+        },
+        writerOpts: {
+          groupBy: 'type',
+          commitGroupsSort: 'title',
+          commitsSort: ['scope', 'subject'],
+          noteGroupsSort: 'title',
+          transform: noteTransform,
+        },
       },
     ],
     ['@semantic-release/changelog', { changelogFile: 'docs/CHANGELOG.md' }],


### PR DESCRIPTION
## Why did you create this PR
- Since current release note is messed up 

## What did you do
- Use custom transform release note generator instead
- Allow generate release note for " Create a merge commit" if you provide a note

## Demo
When you want to merge pull request you have 2 options 
1. Create a merge commit

    In this case, you have to use [The Angular Convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines) (e.g. `feat`, `fix`, `perf`, `revert`)  on `description` section to describe the pull request like this. semantic-release will generate note for this PR
    
    **CAUTION**: all commits in the PR SHOULD NOT USE [The Angular Convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines) except you know what you are doing
    
    <img width="843" alt="Screen Shot 2565-01-09 at 20 21 13" src="https://user-images.githubusercontent.com/33742791/148683890-1ff4bbb3-9bed-4791-a3d9-71548bc4da22.png">

2. Squash and merge

    In this case, you don't have to do anything more. Just merge it. But keep in mind that the header (e.g. `fix: world module (#3)`) also needs [The Angular Convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines) 

    <img width="844" alt="Screen Shot 2565-01-09 at 20 16 11" src="https://user-images.githubusercontent.com/33742791/148683701-2729767c-07d5-498a-8b0f-47f7d37acc16.png">

## Checklist
- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!-- 
## Related links
-
-->
 
