### PR TITLE
fix: remove /_api suffix

### DIFF
--- a/apps/cugetreg-api/src/auth/auth.service.ts
+++ b/apps/cugetreg-api/src/auth/auth.service.ts
@@ -43,7 +43,7 @@ export class AuthService {
   }
 
   getGoogleCallbackUrl(overrideBackendUrl: string | undefined): string {
-    const backendApiUrl = overrideBackendUrl ?? `${this.configService.get('backendPublicUrl')}/api`
+    const backendApiUrl = overrideBackendUrl ?? `${this.configService.get('backendPublicUrl')}`
     return `${backendApiUrl}/auth/google/callback`
   }
 


### PR DESCRIPTION
## Why did you create this PR
- https://beta.cugetreg.com authentication is broken, because if duplicate /api suffix in default callback url (since /_api is already present in env)

## What did you do
- Removed duplicate `/api` suffix

<!--
## Related links
-
-->
