### PR TITLE
CRITICAL FIX: escape regex string used in search

### DIFF
--- a/apps/cugetreg-api/src/course/course.service.ts
+++ b/apps/cugetreg-api/src/course/course.service.ts
@@ -4,6 +4,8 @@ import { InjectModel } from '@nestjs/mongoose'
 import { Semester, StudyProgram } from '@thinc-org/chula-courses'
 import { FilterQuery, Model } from 'mongoose'
 
+import { escapeRegExpString } from '@api/util/functions'
+
 import { Course } from '../common/types/course.type'
 import { CourseGroupInput, FilterInput } from '../graphql'
 import { CourseDocument } from '../schemas/course.schema'
@@ -68,10 +70,10 @@ export class CourseService {
     keyword = keyword.trim()
     if (keyword) {
       query.$or = [
-        { courseNo: new RegExp('^' + keyword, 'i') },
-        { abbrName: new RegExp(keyword, 'i') },
-        { courseNameTh: new RegExp(keyword, 'i') },
-        { courseNameEn: new RegExp(keyword, 'i') },
+        { courseNo: new RegExp('^' + escapeRegExpString(keyword), 'i') },
+        { abbrName: new RegExp(escapeRegExpString(keyword), 'i') },
+        { courseNameTh: new RegExp(escapeRegExpString(keyword), 'i') },
+        { courseNameEn: new RegExp(escapeRegExpString(keyword), 'i') },
       ]
     }
 

--- a/apps/cugetreg-api/src/course/course.service.ts
+++ b/apps/cugetreg-api/src/course/course.service.ts
@@ -67,13 +67,13 @@ export class CourseService {
       academicYear,
       studyProgram,
     } as FilterQuery<CourseDocument>
-    keyword = keyword.trim()
+    const escapedKeyword = escapeRegExpString(keyword.trim())
     if (keyword) {
       query.$or = [
-        { courseNo: new RegExp('^' + escapeRegExpString(keyword), 'i') },
-        { abbrName: new RegExp(escapeRegExpString(keyword), 'i') },
-        { courseNameTh: new RegExp(escapeRegExpString(keyword), 'i') },
-        { courseNameEn: new RegExp(escapeRegExpString(keyword), 'i') },
+        { courseNo: new RegExp('^' + escapedKeyword, 'i') },
+        { abbrName: new RegExp(escapedKeyword, 'i') },
+        { courseNameTh: new RegExp(escapedKeyword, 'i') },
+        { courseNameEn: new RegExp(escapedKeyword, 'i') },
       ]
     }
 

--- a/apps/cugetreg-api/src/util/functions.ts
+++ b/apps/cugetreg-api/src/util/functions.ts
@@ -38,3 +38,11 @@ export function findAvgRating(reviews: Review[]): string {
   }
   return (total / (2 * reviews.length)).toFixed(2)
 }
+
+/**
+ * Escapes a string to be safely used in a regex query.
+ * @param str The string to be escaped
+ */
+export function escapeRegExpString(str: string): string {
+  return str.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')
+}


### PR DESCRIPTION
## Why did you create this PR
Currently, when searching courses, the keyword is dangerously fed into the RegExp pattern and sent to MongoDB. With certain patterns (`([A-Z ]+)+l` for example), it can cause the server to take insane amount of time and processing power to process the request, which can cause the server to be unresponsive.

Thanks @saengowp for the report.

## What did you do
- Escape the keyword before passing them to MongoDB
Here is the result after the fix.
<img width="1469" alt="image" src="https://user-images.githubusercontent.com/24814968/187086243-d6ffb02d-13aa-4d0e-98e3-6a03982779a2.png">


## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [x] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
