### PR TITLE
fix: update override schema to match scraper

### DIFF
--- a/apps/cugetreg-api/.gitignore
+++ b/apps/cugetreg-api/.gitignore
@@ -5,3 +5,5 @@
 .env.production
 .env.local.development
 .env.local.production
+
+generate-typings.js

--- a/apps/cugetreg-api/src/graphql.ts
+++ b/apps/cugetreg-api/src/graphql.ts
@@ -127,6 +127,8 @@ export abstract class IQuery {
 
     abstract search(filter: FilterInput, courseGroup: CourseGroupInput): Course[] | Promise<Course[]>;
 
+    abstract overrides(): Override[] | Promise<Override[]>;
+
     abstract reviews(courseNo: string, studyProgram: StudyProgram): Review[] | Promise<Review[]>;
 
     abstract myPendingReviews(courseNo: string, studyProgram: StudyProgram): Review[] | Promise<Review[]>;

--- a/apps/cugetreg-api/src/override/override.graphql
+++ b/apps/cugetreg-api/src/override/override.graphql
@@ -36,6 +36,10 @@ input OverrideInput {
   genEd: GenEdOverrideInput
 }
 
+type Query {
+  overrides: [Override!]!
+}
+
 type Mutation {
   """
   Create a new override. If override already exists, update it.

--- a/apps/cugetreg-api/src/override/override.resolver.ts
+++ b/apps/cugetreg-api/src/override/override.resolver.ts
@@ -13,7 +13,6 @@ import { OverrideService } from './override.service'
 export class OverrideResolver {
   constructor(private readonly overrideService: OverrideService) {}
 
-  @UseGuards(AdminAuthGuard)
   @Query('overrides')
   getOverrides(): Promise<Override[]> {
     return this.overrideService.getOverrides()

--- a/apps/cugetreg-api/src/override/override.resolver.ts
+++ b/apps/cugetreg-api/src/override/override.resolver.ts
@@ -1,15 +1,23 @@
 import { UseGuards } from '@nestjs/common'
-import { Args, Mutation, Resolver } from '@nestjs/graphql'
+import { Args, Mutation, Query, Resolver } from '@nestjs/graphql'
 
 import { StudyProgram } from '@thinc-org/chula-courses'
 
-import { AdminAuthGuard } from '../auth/admin.guard'
-import { OverrideInput } from '../graphql'
+import { AdminAuthGuard } from '@api/auth/admin.guard'
+import { OverrideInput } from '@api/graphql'
+import { Override } from '@api/schemas/override.schema'
+
 import { OverrideService } from './override.service'
 
 @Resolver('Override')
 export class OverrideResolver {
   constructor(private readonly overrideService: OverrideService) {}
+
+  @UseGuards(AdminAuthGuard)
+  @Query('overrides')
+  getOverrides(): Promise<Override[]> {
+    return this.overrideService.getOverrides()
+  }
 
   @UseGuards(AdminAuthGuard)
   @Mutation('createOrUpdateOverride')

--- a/apps/cugetreg-api/src/schemas/override.schema.ts
+++ b/apps/cugetreg-api/src/schemas/override.schema.ts
@@ -1,24 +1,29 @@
-import { GenEdType, StudyProgram } from '@thinc-org/chula-courses'
 import * as mongoose from 'mongoose'
+
+import { GenEdType, StudyProgram } from '@api/graphql'
 
 export const GenEdSchema = new mongoose.Schema({
   genEdType: {
     type: String,
     required: true,
-    enum: ['SC', 'SO', 'HU', 'IN', 'NO'],
+    enum: Object.values(GenEdType),
   },
   sections: { type: [String], required: true },
 })
 
 export const OverrideSchema = new mongoose.Schema({
   courseNo: { type: String, required: true },
-  studyProgram: { type: String, required: true, enum: ['S', 'T', 'I'] },
+  studyProgram: { type: String, required: true, enum: Object.values(StudyProgram) },
+  semester: { type: String, required: true },
+  academicYear: { type: String, required: true },
   genEd: { type: GenEdSchema },
 })
 
 export interface Override {
   courseNo: string
   studyProgram: StudyProgram
+  semester: string
+  academicYear: string
   genEd?: {
     genEdType: GenEdType
     sections: string[]


### PR DESCRIPTION
## Why did you create this PR
Override schema in `cugetreg-api` does not match the one in [thinc-org/cugetreg-scraper](https://github.com/thinc-org/cugetreg-scraper). I don't know how the fuck it worked until now.

## What did you do
- Update `override.schema.ts` to match the one used by scraper
  - Added `semester` and `academicYear` fields
  - Use enums in graphql declaration for schema declaration, instead of using [thinc-org/chula-courses](https://github.com/thinc-org/chula-courses)
- Add `overrides` query to return all overrides (this was already implemented in OverrideService, it just wasn't exposed as a query)
  - Note: this query is intentionally left unprotected since it's public data

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [x] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
