### PR TITLE
Ensure indices on course and review collections

### DIFF
--- a/apps/cugetreg-api/src/schemas/course.schema.ts
+++ b/apps/cugetreg-api/src/schemas/course.schema.ts
@@ -88,4 +88,7 @@ export const CourseSchema = new mongoose.Schema({
   rating: { type: String },
 })
 
+CourseSchema.index({ studyProgram: 1, academicYear: 1, semester: 1, courseNo: 1 })
+CourseSchema.index({ studyProgram: 1, academicYear: 1, semester: 1, abbrName: 1 })
+
 export type CourseDocument = Course & mongoose.Document

--- a/apps/cugetreg-api/src/schemas/review.schema.ts
+++ b/apps/cugetreg-api/src/schemas/review.schema.ts
@@ -32,6 +32,8 @@ export const ReviewSchema = new mongoose.Schema({
   },
 })
 
+ReviewSchema.index({ studyProgram: 1, courseNo: 1 })
+
 export interface ReviewInteraction {
   userId: mongoose.Types.ObjectId
   type: ReviewInteractionType


### PR DESCRIPTION
ok im sorry, i know we agreed we won't be coding anymore, but i just can't help it

## Why did you create this PR
- We created indices manually on MongoDB production db, but we forgot to ensure it in the source code. This is why it's slow on beta and dev. It's also tiresome when we want to add new indices, since we have to manually ssh and create indices on all 3 environments

## What did you do
- Removed old index (`studyProgram, academicYear, semester`) in favor of the new ones
- Ensure indices on the following collections
### Course
All queries to course have `studyProgram, academicYear, semester`, so it'll **always** utilize either of these indices at minimum. This also makes scraper save much faster too (from ~1,900 seconds to ~800 seconds).
1. (`studyProgram, academicYear, semester, courseNo`) -> fast query during search with courseNo, extremely fast since courseNo searches with prefix regexp
2. (`studyProgram, academicYear, semester, abbrName`) -> fast query with course abbrName
Note: I tried defining courseNo/abbrName first in the index order, but that resulted in more index keys being examined (as expected)

### Review
1. (`studyProgram, courseNo`) -> faster query on all user queries on reviews

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [x] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
