### PR TITLE
fix override mutation apis to correctly identify overrides

### DIFF
--- a/apps/cugetreg-api/src/graphql.ts
+++ b/apps/cugetreg-api/src/graphql.ts
@@ -245,7 +245,7 @@ export class Override {
 export abstract class IMutation {
     abstract createOrUpdateOverride(override: OverrideInput): Override | Promise<Override>;
 
-    abstract deleteOverride(courseNo: string, studyProgram: StudyProgram): Override | Promise<Override>;
+    abstract deleteOverride(courseNo: string, courseGroup: CourseGroupInput): Override | Promise<Override>;
 
     abstract createReview(createReviewInput: CreateReviewInput): Review | Promise<Review>;
 

--- a/apps/cugetreg-api/src/override/override.graphql
+++ b/apps/cugetreg-api/src/override/override.graphql
@@ -52,5 +52,5 @@ type Mutation {
 
   Requires admin authentication.
   """
-  deleteOverride(courseNo: String!, studyProgram: StudyProgram!): Override
+  deleteOverride(courseNo: String!, courseGroup: CourseGroupInput!): Override
 }

--- a/apps/cugetreg-api/src/override/override.resolver.ts
+++ b/apps/cugetreg-api/src/override/override.resolver.ts
@@ -1,8 +1,6 @@
 import { UseGuards } from '@nestjs/common'
 import { Args, Mutation, Query, Resolver } from '@nestjs/graphql'
 
-import { StudyProgram } from '@thinc-org/chula-courses'
-
 import { AdminAuthGuard } from '@api/auth/admin.guard'
 import { CourseGroupInput, OverrideInput } from '@api/graphql'
 import { Override } from '@api/schemas/override.schema'

--- a/apps/cugetreg-api/src/override/override.resolver.ts
+++ b/apps/cugetreg-api/src/override/override.resolver.ts
@@ -4,7 +4,7 @@ import { Args, Mutation, Query, Resolver } from '@nestjs/graphql'
 import { StudyProgram } from '@thinc-org/chula-courses'
 
 import { AdminAuthGuard } from '@api/auth/admin.guard'
-import { OverrideInput } from '@api/graphql'
+import { CourseGroupInput, OverrideInput } from '@api/graphql'
 import { Override } from '@api/schemas/override.schema'
 
 import { OverrideService } from './override.service'
@@ -28,8 +28,9 @@ export class OverrideResolver {
   @Mutation('deleteOverride')
   deleteOverride(
     @Args('courseNo') courseNo: string,
-    @Args('studyProgram') studyProgram: StudyProgram
+    @Args('courseGroup') courseGroup: CourseGroupInput
   ) {
-    return this.overrideService.deleteOverride(courseNo, studyProgram)
+    const { studyProgram, academicYear, semester } = courseGroup
+    return this.overrideService.deleteOverride(courseNo, studyProgram, academicYear, semester)
   }
 }

--- a/apps/cugetreg-api/src/override/override.service.ts
+++ b/apps/cugetreg-api/src/override/override.service.ts
@@ -25,6 +25,8 @@ export class OverrideService {
         {
           courseNo: override.courseNo,
           studyProgram: override.studyProgram,
+          academicYear: override.academicYear,
+          semester: override.semester,
         },
         override,
         {
@@ -36,10 +38,17 @@ export class OverrideService {
     return result
   }
 
-  async deleteOverride(courseNo: string, studyProgram: StudyProgram): Promise<Override> {
+  async deleteOverride(
+    courseNo: string,
+    studyProgram: StudyProgram,
+    academicYear: string,
+    semester: string
+  ): Promise<Override> {
     const result = await this.overrideModel.findOneAndDelete({
       courseNo,
       studyProgram,
+      academicYear,
+      semester,
     })
     return result
   }


### PR DESCRIPTION
## Why did you create this PR
- `createOrUpdateOverride` and `deleteOverride` is supposed to identify overrides with `semester` and `academicYear` also, but i forgot to implement it.

## What did you do
- Make both mutations use `semester` and `academicYear` in their queries.

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
