### PR TITLE
Checkout 'before' ref for compare

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,17 +32,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        name: Checkout [Pull Request]
-        if: ${{ github.event_name == 'pull_request' }}
+        name: Checkout Before
         with:
-          # By default, PRs will be checked-out based on the Merge Commit, but we want the actual branch HEAD.
-          ref: ${{ github.event.pull_request.head.sha }}
-          # We need to fetch all branches and commits so that Nx affected has a base to compare against.
+          ref: ${{ github.event.before }}
           fetch-depth: 0
 
       - uses: actions/checkout@v2
-        name: Checkout [Default Branch]
-        if: ${{ github.event_name != 'pull_request' }}
+        name: Checkout
         with:
           # We need to fetch all branches and commits so that Nx affected has a base to compare against.
           fetch-depth: 0

--- a/tools/set-affected-apps-env
+++ b/tools/set-affected-apps-env
@@ -6,6 +6,7 @@ if OUTPUT=$(npx nx affected:apps --base=${AFFECTED_BASE} --plain 2> /dev/null); 
   AFFECTED_APPS=$(echo $OUTPUT | tail -1)
 else
   # TODO: replace with list of all apps
+  echo "Could not find ref ${AFFECTED_BASE}, using all apps"
   AFFECTED_APPS="cugetreg-api cugetreg-web"
 fi
 


### PR DESCRIPTION
## Why did you create this PR
When force pushing to a branch, we don't have the 'before' commit in the local git tree, making it impossible to compare changes against, so we used building all apps as fallback.

## What did you do
Use the checkout action to checkout the 'before' commit, then continue the process as normal. This way, the 'before' commit will be available for comparison.
Also removed checkout for PRs because we don't do deploy on PRs.

## Demo

- [Run #231](https://github.com/thinc-org/cugetreg/runs/8198475254?check_suite_focus=true): Force push, all apps changed
- [Run #232](https://github.com/thinc-org/cugetreg/runs/8198519894?check_suite_focus=true): Force push, no apps changed

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
