### PR TITLE
Fix inconsistent background color in ConfigSelect

### DIFF
--- a/apps/cugetreg-web/src/common/components/TopBar/components/ConfigSelect/index.tsx
+++ b/apps/cugetreg-web/src/common/components/TopBar/components/ConfigSelect/index.tsx
@@ -32,7 +32,7 @@ export const ConfigBarSelect = styled(NativeSelect)`
   }
 
   option {
-    ${({ theme }) => theme.breakpoints.up('sm')} {
+    ${({ theme }) => theme.breakpoints.up('md')} {
       background-color: ${({ theme }) => theme.palette.primary.main} !important;
     }
   }


### PR DESCRIPTION
## Why did you create this PR

- I have found that StudyProgramDropdown choice and TermDropdown choice have text color that blend with background color if it does not hover at width 600px - 960px

![image](https://user-images.githubusercontent.com/35169079/197326350-fe0a4b92-ab1a-4422-8474-5d7bf8afacc2.png)

## What did you do

- I have fixed ConfigSelect to correctly display text color

![image](https://user-images.githubusercontent.com/35169079/197326378-74adf33f-8d01-4b32-9852-f09c28bc31ad.png)

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
