### PR TITLE
fix nx cloud version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,12 +13,12 @@ jobs:
     with:
       number-of-agents: 3
       parallel-commands: |
-        npx nx-cloud record -- npx nx workspace-lint
-        npx nx-cloud record -- npx nx format:check
+        npx nx-cloud@14.5.5 record -- npx nx@14.5.5 workspace-lint
+        npx nx-cloud@14.5.5 record -- npx nx@14.5.5 format:check
       parallel-commands-on-agents: |
-        npx nx affected --target=lint --parallel=3 --base=${{ github.event.before || github.base.sha }} --head=HEAD
-        npx nx affected --target=test --parallel=3 --ci --code-coverage --base=${{ github.event.before || github.base.sha }} --head=HEAD
-        npx nx affected --target=build --parallel=3 --base=${{ github.event.before || github.base.sha }} --head=HEAD
+        npx nx@14.5.5 affected --target=lint --parallel=3 --base=${{ github.event.before || github.base.sha }} --head=HEAD
+        npx nx@14.5.5 affected --target=test --parallel=3 --ci --code-coverage --base=${{ github.event.before || github.base.sha }} --head=HEAD
+        npx nx@14.5.5 affected --target=build --parallel=3 --base=${{ github.event.before || github.base.sha }} --head=HEAD
       main-branch-name: master
 
   agents:

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "@nrwl/linter": "14.5.5",
     "@nrwl/nest": "^14.5.5",
     "@nrwl/node": "14.5.5",
-    "@nrwl/nx-cloud": "latest",
+    "@nrwl/nx-cloud": "14.5.5",
     "@nrwl/react": "14.5.5",
     "@nrwl/web": "14.5.5",
     "@nrwl/workspace": "14.5.5",


### PR DESCRIPTION
## Why did you create this PR

- Because someone puts `@nrwl/nx-cloud` as latest, so the major version is different from all `@nrwl/*` packages

## What did you do

- Set `@nrwl/nx-cloud` to `14.5.5` like the rest of them

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
