### PR TITLE
[Fix] CI fail when squashing commit

### DIFF
--- a/.github/workflows/reusable-ci.yaml
+++ b/.github/workflows/reusable-ci.yaml
@@ -48,8 +48,8 @@ jobs:
         uses: tj-actions/branch-names@v6
 
       - name: Echo base branch name
-        run: echo ${{ steps.branch-name.outputs.base_ref_branch }}
+        run: echo ${{ steps.branch-name.outputs.base_ref_branch || 'main' }}
 
       - name: Target
         if: ${{ inputs.target }}
-        run: npx nx affected --target=${{ inputs.target }} --parallel=3 --base=origin/${{ steps.branch-name.outputs.base_ref_branch }} --head=HEAD
+        run: npx nx affected --target=${{ inputs.target }} --parallel=3 --base=origin/${{ steps.branch-name.outputs.base_ref_branch || 'main' }} --head=HEAD


### PR DESCRIPTION
## Why did you create this PR

- The base ref is gone when merging using squash commit. As you can see here 

https://github.com/thinc-org/cugetreg/actions/runs/3663669612

<img width="859" alt="Screen Shot 2565-12-10 at 16 52 48" src="https://user-images.githubusercontent.com/33742791/206847355-23c5ced5-4598-4239-bfa7-91032fa67df1.png">


## What did you do

- Set the default base name to the action

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
