### PR TITLE
Fix Readme.md Contribution Guide Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,8 @@ We saw this problem and built [CU Get Reg](https://cugetreg.com) to make this pl
 
 CU Get Reg is open source - we welcome all developers. If you want to be a part of CU Get Reg and improve Chulalongkorn University society, you can start here!
 
-- [Contribution Guides](https://github.com/thinc-org/cugetreg/wiki/Contribution-Guide)
-- [Set up your local environments](https://github.com/thinc-org/cugetreg/wiki/Contribution-Guide)
-- [Explore issues](https://github.com/thinc-org/cugetreg-frontend/issues)
+- [Contribution Guide](https://github.com/thinc-org/cugetreg/wiki/Contribution-Guide)
+- [Explore issues](https://github.com/thinc-org/cugetreg/issues)
 - [Our Roadmap](https://github.com/thinc-org/cugetreg/wiki/Contribution-Guide)
 
 <div id="roadmap"></div>

--- a/README.md
+++ b/README.md
@@ -47,16 +47,16 @@ We saw this problem and built [CU Get Reg](https://cugetreg.com) to make this pl
 
 CU Get Reg is open source - we welcome all developers. If you want to be a part of CU Get Reg and improve Chulalongkorn University society, you can start here!
 
-- [Contribution Guides](#https://github.com/thinc-org/cugetreg-frontend/wiki/Contribution-Guides)
-- [Set up your local environments](https://github.com/thinc-org/cugetreg-frontend/wiki/Contribution-Guides)
+- [Contribution Guides](https://github.com/thinc-org/cugetreg/wiki/Contribution-Guide)
+- [Set up your local environments](https://github.com/thinc-org/cugetreg/wiki/Contribution-Guide)
 - [Explore issues](https://github.com/thinc-org/cugetreg-frontend/issues)
-- [Our Roadmap](https://github.com/thinc-org/cugetreg-frontend/wiki/Contribution-Guides)
+- [Our Roadmap](https://github.com/thinc-org/cugetreg/wiki/Contribution-Guide)
 
 <div id="roadmap"></div>
 
 ## Roadmap
 
-Read more at [Roadmap](https://github.com/thinc-org/cugetreg-frontend/wiki/Contribution-Guides)
+Read more at [Roadmap](https://github.com/thinc-org/cugetreg/wiki/Contribution-Guide)
 
 <div id="contributors"></div>
 


### PR DESCRIPTION
## Why did you create this PR

- Fix Wrong Document Link in Readme.md Result in wrong result

## What did you do

- Change link from old repository (frontend) to https://github.com/thinc-org/cugetreg/wiki/Contribution-Guide

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
