### PR TITLE
Follow up #470: improve release-dev workflow

### DIFF
--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - dev
-      - fix/release-dev-comments
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -67,17 +67,8 @@ jobs:
       - name: Generate affected packages
         id: affected-packages
         run: |
-          ITER=0
           PACKAGES='${{ steps.affected-apps.outputs.packages }}'
-          for PACKAGE in $(echo "$PACKAGES" | jq -r '.[]' ); do
-            if [ "$ITER" = "0" ]; then
-              PACKAGES_OUTPUT=$(echo "[{\"name\":\"${PACKAGE}\",\"version\":\"dev\"}")
-              ITER=$(expr $ITER + 1)
-            else
-              PACKAGES_OUTPUT=$(echo "${PACKAGES_OUTPUT},{\"name\":\"${PACKAGE}\",\"version\":\"dev\"}")
-            fi
-          done
-          PACKAGES_OUTPUT="${PACKAGES_OUTPUT}]"
+          PACKAGES_OUTPUT=$(echo $PACKAGES | jq -c 'map_values({name:.,version:"dev"})')
           echo "affectPackages=$PACKAGES_OUTPUT" >> $GITHUB_OUTPUT
           echo "affectPackages=$PACKAGES_OUTPUT"
 

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -54,21 +54,8 @@ jobs:
           version: 7
           run_install: false
 
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        run: |
-          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
-
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: pnpm install --global turbo
 
       - name: Get affected app names
         id: affected-apps

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -55,7 +55,7 @@ jobs:
           version: 7
           run_install: false
 
-      - name: Install dependencies
+      - name: Install turbo
         run: pnpm install --global turbo
 
       - name: Get affected app names

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - dev
+      - fix/release-dev-comments
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
## Why did you create this PR
To follow up unresolved comments in #470.

## What did you do
The following improvements in the release-dev workflow
- Only install turbo cli instead of **all** dependencies
- Use jq map to transform values instead of manual concatenation

## Demo
[Action run](https://github.com/thinc-org/cugetreg/actions/runs/4076331027/jobs/7023917355)
Before:
<img width="301" alt="image" src="https://user-images.githubusercontent.com/8080853/216378198-478d8a98-2727-4e78-817e-23b5c2097901.png">
After:
<img width="292" alt="image" src="https://user-images.githubusercontent.com/8080853/216378254-fd3194cb-090d-4f9a-9dfa-e375e560772b.png">
