### PR TITLE
add lib to web dockerfile

### DIFF
--- a/.changeset/early-dryers-sip.md
+++ b/.changeset/early-dryers-sip.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+add lib to web dockerfile

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,16 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "admin-api": "0.0.1",
+    "admin-web": "0.0.0",
+    "api": "0.0.0",
+    "reg-scraper": "0.0.0",
+    "web": "0.0.0",
+    "@cgr/codegen": "0.0.0",
+    "@cgr/course-utils": "0.0.0",
+    "eslint-config-custom": "0.0.0",
+    "tsconfig": "0.0.0"
+  },
+  "changesets": []
+}

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -50,6 +50,10 @@ RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 USER nextjs
 
+RUN apk add --no-cache --update --no-cache \
+    cairo \
+    pango 
+
 COPY --from=builder /app/apps/web/next.config.js .
 COPY --from=builder /app/apps/web/package.json .
 


### PR DESCRIPTION
## Why did you create this PR

- Web prod threw this error
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/24814968/216778521-2e4df8d8-9ae4-4683-b799-f87315502058.png">
Which seems like it was missing dependencies in the runtime, weirdly

## What did you do
- Install `cairo` and `pango` in runtime stage

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
