### PR TITLE
Fix docker compose undefined network

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,3 +11,6 @@ services:
       - 27017:27017
     networks:
       - cugetreg-network
+
+networks:
+  cugetreg-network:


### PR DESCRIPTION
## Why did you create this PR

- If the Docker network `cugetreg-network` hasn't been created on one's machine before, the compose file will fail to start due to
```
service "mongo" refers to undefined network cugetreg-network: invalid compose project
```
- If the `cugetreg-network` exists on one's machine, they should add the `external` key by themselves instead

## What did you do

- Add `cugetreg-network` to networks in `docker-compose.yaml`

## Demo

(inapplicable)

## Checklist

- [ ] Deploy a demo (inapplicable)
- [ ] Check browsers compatibility (inapplicable)
- [ ] Wrote coverage tests (inapplicable)

<!--
## Related links
-
-->
