### PR TITLE
add class validator and class transformer in all nest apps

### DIFF
--- a/.changeset/nice-ladybugs-give.md
+++ b/.changeset/nice-ladybugs-give.md
@@ -1,0 +1,7 @@
+---
+"admin-api": patch
+"api": patch
+"reg-scraper": patch
+---
+
+Fix duplicate @nestjs/common entries problem by adding class validator and class transformer in all Nest apps. This is a short term solution.

--- a/apps/admin-api/package.json
+++ b/apps/admin-api/package.json
@@ -17,6 +17,8 @@
     "@nestjs/common": "9.2.1",
     "@nestjs/core": "9.2.1",
     "@nestjs/platform-express": "9.2.1",
+    "class-transformer": "0.3.1",
+    "class-validator": "0.13.2",
     "rxjs": "^7.2.0"
   },
   "devDependencies": {

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -39,6 +39,7 @@
     "@thinc-org/chula-courses": "^2.3.0",
     "@typegoose/typegoose": "9.1.0",
     "apollo-server-express": "2.19.2",
+    "class-transformer": "0.3.1",
     "class-validator": "0.13.2",
     "cookie-parser": "1.4.6",
     "google-auth-library": "^8.7.0",

--- a/apps/reg-scraper/package.json
+++ b/apps/reg-scraper/package.json
@@ -29,6 +29,8 @@
     "@nestjs/platform-express": "9.2.1",
     "@nestjs/schedule": "2.1.0",
     "@thinc-org/chula-courses": "^2.3.0",
+    "class-transformer": "0.3.1",
+    "class-validator": "0.13.2",
     "axios": "0.23.0",
     "bull": "4.10.2",
     "cheerio": "1.0.0-rc.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
       '@changesets/cli': 2.26.0
       '@trivago/prettier-plugin-sort-imports': 4.0.0_7yjediqwct5rofa5licti4izue
       prettier: 2.8.3
-      turbo: 1.7.2
+      turbo: 1.7.3
 
   apps/admin-api:
     specifiers:
@@ -25,6 +25,8 @@ importers:
       '@types/express': ^4.17.16
       '@types/jest': 28.1.8
       '@types/node': ^18.11.18
+      class-transformer: 0.3.1
+      class-validator: 0.13.2
       eslint: 7.32.0
       eslint-config-custom: workspace:*
       jest: 28.1.3
@@ -34,9 +36,11 @@ importers:
       typescript: ~4.7.4
     dependencies:
       '@nestjs/cli': 9.1.9
-      '@nestjs/common': 9.2.1_mnr6j2del53muneqly5h4y27ai
+      '@nestjs/common': 9.2.1_huyc3vjxdj723rrinn6lunzxyq
       '@nestjs/core': 9.2.1_e6la6qvsclaae2becwjnmfvsuq
       '@nestjs/platform-express': 9.2.1_hjcqpoaebdr7gdo5hgc22hthbe
+      class-transformer: 0.3.1
+      class-validator: 0.13.2
       rxjs: 7.8.0
     devDependencies:
       '@types/express': 4.17.16
@@ -99,6 +103,7 @@ importers:
       '@types/jest': 28.1.8
       '@types/node': ^18.11.18
       apollo-server-express: 2.19.2
+      class-transformer: 0.3.1
       class-validator: 0.13.2
       cookie-parser: 1.4.6
       eslint: 7.32.0
@@ -136,6 +141,7 @@ importers:
       '@thinc-org/chula-courses': 2.3.0
       '@typegoose/typegoose': 9.1.0_mongoose@6.5.2
       apollo-server-express: 2.19.2_graphql@15.5.0
+      class-transformer: 0.3.1
       class-validator: 0.13.2
       cookie-parser: 1.4.6
       google-auth-library: 8.7.0
@@ -180,6 +186,8 @@ importers:
       axios: 0.23.0
       bull: 4.10.2
       cheerio: 1.0.0-rc.12
+      class-transformer: 0.3.1
+      class-validator: 0.13.2
       csv-parse: ^5.3.3
       date-fns: ^2.29.3
       eslint: 7.32.0
@@ -196,7 +204,7 @@ importers:
       winston: ^3.8.2
     dependencies:
       '@nestjs/bull': 0.6.2_5g4fguw5dzljhwwr66uekbkoti
-      '@nestjs/common': 9.2.1_mnr6j2del53muneqly5h4y27ai
+      '@nestjs/common': 9.2.1_huyc3vjxdj723rrinn6lunzxyq
       '@nestjs/config': 2.2.0_b4pxbpa7chblgbyake5iz5rdmu
       '@nestjs/core': 9.2.1_e6la6qvsclaae2becwjnmfvsuq
       '@nestjs/mongoose': 9.2.1_qllokwhbbxyphnu7erbtzw5xuq
@@ -206,6 +214,8 @@ importers:
       axios: 0.23.0
       bull: 4.10.2
       cheerio: 1.0.0-rc.12
+      class-transformer: 0.3.1
+      class-validator: 0.13.2
       csv-parse: 5.3.3
       date-fns: 2.29.3
       http-cookie-agent: 5.0.2_tough-cookie@4.1.2
@@ -2319,7 +2329,7 @@ packages:
       '@nestjs/common': ^6.10.11 || ^7.0.0 || ^8.0.0 || ^9.0.0
       '@nestjs/core': ^6.10.11 || ^7.0.0 || ^8.0.0 || ^9.0.0
     dependencies:
-      '@nestjs/common': 9.2.1_mnr6j2del53muneqly5h4y27ai
+      '@nestjs/common': 9.2.1_huyc3vjxdj723rrinn6lunzxyq
       '@nestjs/core': 9.2.1_e6la6qvsclaae2becwjnmfvsuq
       tslib: 2.4.1
     dev: false
@@ -2332,7 +2342,7 @@ packages:
       bull: ^3.3 || ^4.0.0
     dependencies:
       '@nestjs/bull-shared': 0.1.2_hjcqpoaebdr7gdo5hgc22hthbe
-      '@nestjs/common': 9.2.1_mnr6j2del53muneqly5h4y27ai
+      '@nestjs/common': 9.2.1_huyc3vjxdj723rrinn6lunzxyq
       '@nestjs/core': 9.2.1_e6la6qvsclaae2becwjnmfvsuq
       bull: 4.10.2
       tslib: 2.4.1
@@ -2397,29 +2407,6 @@ packages:
       uuid: 9.0.0
     dev: false
 
-  /@nestjs/common/9.2.1_mnr6j2del53muneqly5h4y27ai:
-    resolution: {integrity: sha512-nZuo3oDsSSlC5mti/M2aCWTEIfHPGDXmBwWgPeCpRbrNz3IWd109rkajll+yxgidVjznAdBS9y00JkAVJblNYw==}
-    peerDependencies:
-      cache-manager: <=5
-      class-transformer: '*'
-      class-validator: '*'
-      reflect-metadata: ^0.1.12
-      rxjs: ^7.1.0
-    peerDependenciesMeta:
-      cache-manager:
-        optional: true
-      class-transformer:
-        optional: true
-      class-validator:
-        optional: true
-    dependencies:
-      iterare: 1.2.1
-      reflect-metadata: 0.1.13
-      rxjs: 7.8.0
-      tslib: 2.4.1
-      uuid: 9.0.0
-    dev: false
-
   /@nestjs/config/2.2.0_b4pxbpa7chblgbyake5iz5rdmu:
     resolution: {integrity: sha512-78Eg6oMbCy3D/YvqeiGBTOWei1Jwi3f2pSIZcZ1QxY67kYsJzTRTkwRT8Iv30DbK0sGKc1mcloDLD5UXgZAZtg==}
     peerDependencies:
@@ -2454,7 +2441,7 @@ packages:
       '@nestjs/websockets':
         optional: true
     dependencies:
-      '@nestjs/common': 9.2.1_mnr6j2del53muneqly5h4y27ai
+      '@nestjs/common': 9.2.1_huyc3vjxdj723rrinn6lunzxyq
       '@nestjs/platform-express': 9.2.1_hjcqpoaebdr7gdo5hgc22hthbe
       '@nuxtjs/opencollective': 0.3.2
       fast-safe-stringify: 2.1.1
@@ -2564,7 +2551,7 @@ packages:
       '@nestjs/common': ^9.0.0
       '@nestjs/core': ^9.0.0
     dependencies:
-      '@nestjs/common': 9.2.1_mnr6j2del53muneqly5h4y27ai
+      '@nestjs/common': 9.2.1_huyc3vjxdj723rrinn6lunzxyq
       '@nestjs/core': 9.2.1_e6la6qvsclaae2becwjnmfvsuq
       body-parser: 1.20.1
       cors: 2.8.5
@@ -12119,65 +12106,65 @@ packages:
       yargs: 17.6.2
     dev: true
 
-  /turbo-darwin-64/1.7.2:
-    resolution: {integrity: sha512-Sml3WR8MSu80W+gS8SnoKNImcDOlIX7zlvezzds65mW11yGniIFfZ18aKWGOm92Nj2SvXCQ2+UmyGghbFaHNmQ==}
+  /turbo-darwin-64/1.7.3:
+    resolution: {integrity: sha512-7j9+j1CVztmdevnClT3rG/GRhULf3ukwmv+l48l8uwsXNI53zLso+UYMql6RsjZDbD6sESwh0CHeKNwGmOylFA==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64/1.7.2:
-    resolution: {integrity: sha512-JnlgGLScboUJGJxvmSsF+5xkImEDTMPg2FHzX4n8AMB9az9ZlPQAMtc+xu4p6Xp9eaykKiV2RG81YS3H0fxDLA==}
+  /turbo-darwin-arm64/1.7.3:
+    resolution: {integrity: sha512-puS9+pqpiy4MrIvWRBTg3qfO2+JPXR7reQcXQ7qUreuyAJnSw9H9/TIHjeK6FFxUfQbmruylPtH6dNpfcML9CA==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64/1.7.2:
-    resolution: {integrity: sha512-vbLJw6ovG+lpiPqxniscBjljKJ2jbsHuKp8uK4j/wqgp68wAVKeAZW77GGDAUgDb88XH6Kvhh2hcizL+iWduww==}
+  /turbo-linux-64/1.7.3:
+    resolution: {integrity: sha512-BnbpgcK8Wag6fhnff7tMaecswmFHN/T56VIDnjcwcJnK9H3jdwpjwZlmcDtkoslzjPj3VuqHyqLDMvSb3ejXSg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64/1.7.2:
-    resolution: {integrity: sha512-zLnuS8WdHonKL74KqOopOH/leBOWumlVGF8/8hldbDPq0mwY+6myRR5/5LdveB51rkG4UJh/sQ94xV67tjBoyw==}
+  /turbo-linux-arm64/1.7.3:
+    resolution: {integrity: sha512-+epY+0dfjmAJNZHfj7rID2hENRaeM3D0Ijqkhh/M53o46fQMwPNqI5ff9erh+f9r8sWuTpVnRlZeu7TE1P/Okw==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64/1.7.2:
-    resolution: {integrity: sha512-oE5PMoXjmR09okvVzteFb6FjA6yo+nMsacsgKH2yLNq4sOrVo9tG98JkRurOv5+L6ZQ3yGXPxWHiqeH7hLkAVQ==}
+  /turbo-windows-64/1.7.3:
+    resolution: {integrity: sha512-/2Z8WB4fASlq/diO6nhmHYuDCRPm3dkdUE6yhwQarXPOm936m4zj3xGQA2eSWMpvfst4xjVxxU7P7HOIOyWChA==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-arm64/1.7.2:
-    resolution: {integrity: sha512-mdTUJk23acRv5qxA/yEstYhM1VFenVE3FDrssxGRFq7S80smtCGK1xUd4BEDDzDlVXOqBohmM5jRh9516rcjPQ==}
+  /turbo-windows-arm64/1.7.3:
+    resolution: {integrity: sha512-UD9Uhop42xj1l1ba5LRdwqRq1Of+RgqQuv+QMd1xOAZ2FXn/91uhkfLv+H4Pkiw7XdUohOxpj/FcOvjCiiUxGw==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo/1.7.2:
-    resolution: {integrity: sha512-YR/x3GZEx0C1RV6Yvuw/HB1Ixx3upM6ZTTa4WqKz9WtLWN8u2g+u2h5KpG5YtjCS3wl/8zVXgHf2WiMK6KIghg==}
+  /turbo/1.7.3:
+    resolution: {integrity: sha512-mrqo72vPQO6ykmARThaNP/KXPDuBDSqDXfkUxD8hX1ET3YSFbOWJixlHU32tPtiFIhScIKbEGShEVWBrLeM0wg==}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: 1.7.2
-      turbo-darwin-arm64: 1.7.2
-      turbo-linux-64: 1.7.2
-      turbo-linux-arm64: 1.7.2
-      turbo-windows-64: 1.7.2
-      turbo-windows-arm64: 1.7.2
+      turbo-darwin-64: 1.7.3
+      turbo-darwin-arm64: 1.7.3
+      turbo-linux-64: 1.7.3
+      turbo-linux-arm64: 1.7.3
+      turbo-windows-64: 1.7.3
+      turbo-windows-arm64: 1.7.3
     dev: true
 
   /type-check/0.3.2:


### PR DESCRIPTION
## Why did you create this PR
- Read #489 

## What did you do
- Fixes #489 

This is a short term solution. We should not be required to add `class-validator` and `class-transformer` to all nest apps.

<img width="838" alt="image" src="https://user-images.githubusercontent.com/24814968/216809082-9a66784f-deb8-46d8-8ad7-2e0195cf18dc.png">


