### PR TITLE
Sync beta to main after merging Version Packages PR

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,16 @@
+{
+  "mode": "pre",
+  "tag": "beta",
+  "initialVersions": {
+    "admin-api": "0.0.1",
+    "admin-web": "0.0.0",
+    "api": "1.0.0",
+    "reg-scraper": "1.0.0",
+    "web": "1.0.1",
+    "@cgr/codegen": "1.0.0",
+    "@cgr/course-utils": "1.0.0",
+    "eslint-config-custom": "1.0.0",
+    "tsconfig": "1.0.0"
+  },
+  "changesets": []
+}

--- a/.github/workflows/sync-beta.yaml
+++ b/.github/workflows/sync-beta.yaml
@@ -21,8 +21,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    # Only run this job if the pull request is merged and the base branch is beta
-    if: ${{ github.event.pull_request.merged == true && github.head_ref == 'beta' }}
+    # Only run this job if the pull request is merged and the base branch is 'changeset-release/main'
+    if: ${{ github.event.pull_request.merged == true && github.head_ref == 'changeset-release/main' }}
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/sync-beta.yaml
+++ b/.github/workflows/sync-beta.yaml
@@ -1,0 +1,31 @@
+name: Sync beta to main
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  sync:
+    name: Sync beta to main
+
+    strategy:
+      matrix:
+        node-version: [16.17.0]
+        os: [ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          ref: beta
+
+      - name: Echo event payload
+        run: echo ${{ github.event.pull_request.merged }}
+
+      - name: Echo event payload
+        run: echo ${{ toJSON(github.event) }}

--- a/.github/workflows/sync-beta.yaml
+++ b/.github/workflows/sync-beta.yaml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   sync:
     name: Sync beta to main
@@ -18,14 +21,17 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    # Only run this job if the pull request is merged and the base branch is beta
+    if: ${{ github.event.pull_request.merged == true && github.head_ref == 'beta' }}
+
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
           ref: beta
+          fetch-depth: 0
 
-      - name: Echo event payload
-        run: echo ${{ github.event.pull_request.merged }}
-
-      - name: Echo event payload
-        run: echo ${{ toJSON(github.event) }}
+      - name: Rebase beta to main
+        run: |
+          git rebase origin/main
+          git push


### PR DESCRIPTION
## Why did you create this PR
- When we merge changeset's Version Packages PR (see #486), it removes the pre-release configuration and other changeset files. We want those changes to reflect back to beta so those changesets don't appear again when we merge beta to main later.

## What did you do
- Created a workflow file, which executes when the PR is merged and the source branch is `changeset-release` and target branch is `main`. When executed, rebases `beta` branch onto `main`.

## Demo
https://github.com/bombnp/actions-playground/actions/runs/4095898138/jobs/7063149157