### PR TITLE
Disable Google One Tap for ITP browsers

### DIFF
--- a/.changeset/funny-ducks-wash.md
+++ b/.changeset/funny-ducks-wash.md
@@ -1,0 +1,5 @@
+---
+'web': patch
+---
+
+Disable Google One Tap for ITP browsers

--- a/apps/web/src/common/components/GoogleOneTapPrompt/hooks/useGoogleOneTap/index.ts
+++ b/apps/web/src/common/components/GoogleOneTapPrompt/hooks/useGoogleOneTap/index.ts
@@ -15,6 +15,7 @@ export function useGoogleOneTap(promptRef: React.RefObject<HTMLDivElement>) {
       callback: (response: CredentialResponse) => {
         userStore.loginWithIdToken(response.credential)
       },
+      itp_supported: false,
       cancel_on_tap_outside: false,
       prompt_parent_id: promptRef.current.id,
       hosted_domain: 'student.chula.ac.th', // hosted_domain is undocumented in the official documentation


### PR DESCRIPTION
## Why did you create this PR

For browsers that support ITP (Intelligent Tracking Prevention), the Google Sign-In JavaScript library will display a generic prompt instead of the one pre-filled with `student.chula.ac.th` user accounts.

![image](https://user-images.githubusercontent.com/30551284/216873425-a14c28d9-c614-4f39-b919-092ff024a260.png)

Clicking on `Continue` will open an account selection/sign-in popup in which the `hosted_domain` config hasn't been taken into account. Therefore, users could select generic Google accounts or accounts of other domains and get denied eventually, resulting in bad UX. To fix this problem, ITP support could be disabled.

## What did you do

- Disable Google One Tap Prompt for ITP browsers

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com) - dev is not working right now

## Checklist

- [x] Deploy a demo
- [x] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
