### PR TITLE
Enable automatic sign in flow

### DIFF
--- a/.changeset/pretty-lions-applaud.md
+++ b/.changeset/pretty-lions-applaud.md
@@ -1,0 +1,5 @@
+---
+'web': patch
+---
+
+Enable auto sign in flow

--- a/apps/web/src/common/components/GoogleOneTapPrompt/hooks/useGoogleOneTap/index.ts
+++ b/apps/web/src/common/components/GoogleOneTapPrompt/hooks/useGoogleOneTap/index.ts
@@ -15,6 +15,7 @@ export function useGoogleOneTap(promptRef: React.RefObject<HTMLDivElement>) {
       callback: (response: CredentialResponse) => {
         userStore.loginWithIdToken(response.credential)
       },
+      auto_select: true,
       cancel_on_tap_outside: false,
       prompt_parent_id: promptRef.current.id,
       hosted_domain: 'student.chula.ac.th', // hosted_domain is undocumented in the official documentation

--- a/apps/web/src/store/userStore.ts
+++ b/apps/web/src/store/userStore.ts
@@ -37,6 +37,7 @@ class UserStore {
   }
 
   logout = () => {
+    window.google?.accounts?.id?.disableAutoSelect()
     this.setAccessToken(null)
     httpClient.post(`/auth/logout`)
     courseCartStore.upgradeSource()


### PR DESCRIPTION
## Why did you create this PR
The Sign In with Google client library offers an automatic sign in feature that helps improve the UX. When entering the app, the user will be automatically signed in if they have granted access in the past. 
This can be useful when the user has multiple devices, or revisiting users that lost their session.

Related documentation: [Automatic sign-in and sign-out](https://developers.google.com/identity/gsi/web/guides/automatic-sign-in-sign-out)

## What did you do
Enabled the auto sign in flow, and disable it when the user explicitly signs out.

## Demo
Dev is broken, no demo for you 😢
[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
