### PR TITLE
[Fix] Release dev workflow error

### DIFF
--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -42,6 +42,10 @@ on:
         description: Enable updating deployment declaration in the target repository
         type: boolean
         default: false
+      checkout-with-ref:
+        description: Enable checking out the repository with the ref of the package
+        type: boolean
+        default: true
 
 jobs:
   build-and-publish-docker-image:
@@ -59,9 +63,16 @@ jobs:
     steps:
       - name: Checkout with tags
         uses: actions/checkout@v3
+        if: inputs.checkout-with-ref
         with:
           fetch-depth: 0
           ref: refs/tags/${{ matrix.packages.name }}@${{ matrix.packages.version }}
+
+      - name: Checkout without tags
+        uses: actions/checkout@v3
+        if: inputs.checkout-with-ref
+        with:
+          fetch-depth: 0
 
       - name: Check if Dockerfile exists
         id: check-dockerfile

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Checkout without tags
         uses: actions/checkout@v3
-        if: inputs.checkout-with-ref
+        if: inputs.checkout-with-ref == false
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -121,8 +121,8 @@ jobs:
           context: .
           file: apps/${{ env.APP_NAME }}/Dockerfile
           tags: |
-            ${{ inputs.container-registry  }}/${{ inputs.image-prefix }}/${{ env.APP_NAME }}:latest
-            ${{ inputs.container-registry  }}/${{ inputs.image-prefix }}/${{ env.APP_NAME }}:${{ env.VERSION }}
+            ${{ inputs.container-registry }}/${{ inputs.image-prefix }}/${{ env.APP_NAME }}:latest
+            ${{ inputs.container-registry }}/${{ inputs.image-prefix }}/${{ env.APP_NAME }}:${{ env.VERSION }}
           push: ${{ inputs.push }}
         env:
           APP_NAME: ${{ matrix.packages.name }}

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -90,3 +90,4 @@ jobs:
       # target-directory: k8s-demo
       push: true
       update: false
+      checkout-with-ref: false

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Get affected app names
         id: affected-apps
         run: |
-          PACKAGES=$(pnpm turbo run build --filter='...[origin/beta]' --dry=json | jq -c '.packages')
+          PACKAGES=$(pnpm turbo run build --filter='...[origin/beta]' --dry=json | jq -c '.packages | map(select(. != "//"))')
           echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
           echo "packages=$PACKAGES"
 


### PR DESCRIPTION
## Why did you create this PR

- We cannot publish dev Docker images for now

## What did you do

- Filter `//` out from `affectedPackages` and add `checkout-with-tags` to `deploy-docker.yaml` since `dev` branch has no tags, we cannot checkout with the specific version.

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

Workflow https://github.com/thinc-org/cugetreg/actions/runs/4100293129

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
