### PR TITLE
Fix dev workflow

### DIFF
--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -108,14 +108,10 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          file: apps/${{ env.APP_NAME }}/Dockerfile
+          file: apps/${{ matrix.packages.name }}/Dockerfile
           tags: |
-            ${{ inputs.container-registry }}/${{ inputs.image-prefix }}/${{ env.APP_NAME }}:latest
-            ${{ inputs.container-registry }}/${{ inputs.image-prefix }}/${{ env.APP_NAME }}:${{ env.VERSION }}
+            ${{ inputs.container-registry }}/${{ inputs.image-prefix }}/${{ matrix.packages.name }}:${{ matrix.packages.imageTag }}
           push: ${{ inputs.push }}
-        env:
-          APP_NAME: ${{ matrix.packages.name }}
-          VERSION: ${{ matrix.packages.version }}
 
   update-deployment-declaration:
     name: Update deployment declaration

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -42,6 +42,10 @@ on:
         description: Enable updating deployment declaration in the target repository
         type: boolean
         default: false
+      checkout-with-ref:
+        description: Enable checking out the repository with the ref of the package
+        type: boolean
+        default: true
 
 jobs:
   build-and-publish-docker-image:
@@ -59,9 +63,16 @@ jobs:
     steps:
       - name: Checkout with tags
         uses: actions/checkout@v3
+        if: inputs.checkout-with-ref
         with:
           fetch-depth: 0
           ref: refs/tags/${{ matrix.packages.name }}@${{ matrix.packages.version }}
+
+      - name: Checkout without tags
+        uses: actions/checkout@v3
+        if: inputs.checkout-with-ref
+        with:
+          fetch-depth: 0
 
       - name: Check if Dockerfile exists
         id: check-dockerfile

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -113,44 +113,44 @@ jobs:
             ${{ inputs.container-registry }}/${{ inputs.image-prefix }}/${{ matrix.packages.name }}:${{ matrix.packages.imageTag }}
           push: ${{ inputs.push }}
 
-  update-deployment-declaration:
-    name: Update deployment declaration
+  # update-deployment-declaration:
+  #   name: Update deployment declaration
 
-    if: ${{ inputs.update && needs.build-and-publish-docker-image.outputs.DOCKERFILE_EXISTS == 'true' }}
+  #   if: ${{ inputs.update && needs.build-and-publish-docker-image.outputs.DOCKERFILE_EXISTS == 'true' }}
 
-    needs:
-      - build-and-publish-docker-image
+  #   needs:
+  #     - build-and-publish-docker-image
 
-    runs-on: ubuntu-latest
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-        with:
-          repository: ${{ inputs.target-repository }}
-          ref: ${{ inputs.target-ref }}
+  #   steps:
+  #     - name: Checkout Repo
+  #       uses: actions/checkout@v3
+  #       with:
+  #         repository: ${{ inputs.target-repository }}
+  #         ref: ${{ inputs.target-ref }}
 
-      - name: Update publishPackages version in YAML file
-        run: |
-          for row in $(echo "$PACKAGES" | jq -r '.[] | @base64'); do
-            _jq() {
-              echo ${row} | base64 --decode | jq -r ${1}
-            }
-            NAME=$(_jq '.name')
-            VERSION=$(_jq '.version')
-            OLD_VERSION=${{ inputs.container-registry }}\/${{ inputs.image-prefix }}\/$NAME:.*
-            NEW_VERSION=${{ inputs.container-registry }}\/${{ inputs.image-prefix }}\/$NAME:$VERSION
-            find ./${{ inputs.target-directory }} -type f -exec sed -i -e "s|$OLD_VERSION|$NEW_VERSION|g" {} \;
-            echo "${NAME}:${VERSION} is updated"
-          done
-        env:
-          PACKAGES: ${{ inputs.packages }}
+  #     - name: Update publishPackages version in YAML file
+  #       run: |
+  #         for row in $(echo "$PACKAGES" | jq -r '.[] | @base64'); do
+  #           _jq() {
+  #             echo ${row} | base64 --decode | jq -r ${1}
+  #           }
+  #           NAME=$(_jq '.name')
+  #           VERSION=$(_jq '.version')
+  #           OLD_VERSION=${{ inputs.container-registry }}\/${{ inputs.image-prefix }}\/$NAME:.*
+  #           NEW_VERSION=${{ inputs.container-registry }}\/${{ inputs.image-prefix }}\/$NAME:$VERSION
+  #           find ./${{ inputs.target-directory }} -type f -exec sed -i -e "s|$OLD_VERSION|$NEW_VERSION|g" {} \;
+  #           echo "${NAME}:${VERSION} is updated"
+  #         done
+  #       env:
+  #         PACKAGES: ${{ inputs.packages }}
 
-      - name: Show git status
-        run: git status
+  #     - name: Show git status
+  #       run: git status
 
-      - name: Open Pull Request to the target repository
-        uses: peter-evans/create-pull-request@v4
-        with:
-          title: Update Package versions
-          commit-message: Update Package versions
+  #     - name: Open Pull Request to the target repository
+  #       uses: peter-evans/create-pull-request@v4
+  #       with:
+  #         title: Update Package versions
+  #         commit-message: Update Package versions

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -42,10 +42,6 @@ on:
         description: Enable updating deployment declaration in the target repository
         type: boolean
         default: false
-      checkout-with-ref:
-        description: Enable checking out the repository with the ref of the package
-        type: boolean
-        default: true
 
 jobs:
   build-and-publish-docker-image:
@@ -63,16 +59,9 @@ jobs:
     steps:
       - name: Checkout with tags
         uses: actions/checkout@v3
-        if: inputs.checkout-with-ref
         with:
           fetch-depth: 0
-          ref: refs/tags/${{ matrix.packages.name }}@${{ matrix.packages.version }}
-
-      - name: Checkout without tags
-        uses: actions/checkout@v3
-        if: inputs.checkout-with-ref == false
-        with:
-          fetch-depth: 0
+          ref: ${{ matrix.packages.ref }}
 
       - name: Check if Dockerfile exists
         id: check-dockerfile

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Checkout without tags
         uses: actions/checkout@v3
-        if: inputs.checkout-with-ref
+        if: inputs.checkout-with-ref == false
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -121,8 +121,8 @@ jobs:
           context: .
           file: apps/${{ env.APP_NAME }}/Dockerfile
           tags: |
-            ${{ inputs.container-registry  }}/${{ inputs.image-prefix }}/${{ env.APP_NAME }}:latest
-            ${{ inputs.container-registry  }}/${{ inputs.image-prefix }}/${{ env.APP_NAME }}:${{ env.VERSION }}
+            ${{ inputs.container-registry }}/${{ inputs.image-prefix }}/${{ env.APP_NAME }}:latest
+            ${{ inputs.container-registry }}/${{ inputs.image-prefix }}/${{ env.APP_NAME }}:${{ env.VERSION }}
           push: ${{ inputs.push }}
         env:
           APP_NAME: ${{ matrix.packages.name }}

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -90,3 +90,4 @@ jobs:
       # target-directory: k8s-demo
       push: true
       update: false
+      checkout-with-ref: false

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -68,7 +68,7 @@ jobs:
         id: affected-packages
         run: |
           PACKAGES='${{ steps.affected-apps.outputs.packages }}'
-          PACKAGES_OUTPUT=$(echo $PACKAGES | jq -c 'map_values({name:.,version:"dev"})')
+          PACKAGES_OUTPUT=$(echo $PACKAGES | jq -c 'map_values({name:.,ref:"refs/heads/dev",imageTag:"dev"})')
           echo "affectPackages=$PACKAGES_OUTPUT" >> $GITHUB_OUTPUT
           echo "affectPackages=$PACKAGES_OUTPUT"
 

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Get affected app names
         id: affected-apps
         run: |
-          PACKAGES=$(pnpm turbo run build --filter='...[origin/beta]' --dry=json | jq -c '.packages')
+          PACKAGES=$(pnpm turbo run build --filter='...[origin/beta]' --dry=json | jq -c '.packages | map(select(. != "//"))')
           echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
           echo "packages=$PACKAGES"
 

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -90,4 +90,3 @@ jobs:
       # target-directory: k8s-demo
       push: true
       update: false
-      checkout-with-ref: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -97,12 +97,19 @@ jobs:
           version: pnpm changeset version
           publish: pnpm release
 
+      - name: Transform Packages
+        id: transform-packages
+        run: |
+          PACKAGES=$(echo ${{ steps.changesets.outputs.publishedPackages }} | jq -c 'map_values({name:.name,ref:"refs/tags/"+.version,imageTag:.version})')
+          echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
+
       - name: Echo Changeset output
         run: |
           echo "Changeset published - ${{ steps.changesets.outputs.published }}"
           echo "Changeset publishedPackages - ${{ toJSON(steps.changesets.outputs.publishedPackages) }}"
           echo "Changeset hasChangesets - ${{ steps.changesets.outputs.hasChangesets }}"
           echo "Changeset pullRequestNumber - ${{ steps.changesets.outputs.pullRequestNumber }}"
+          echo "Packages to build - ${{ toJSON(steps.transform-packages.outputs.packages) }}"
 
   deploy-with-docker:
     needs:
@@ -129,7 +136,8 @@ jobs:
         [
           {
             "name": "${{ github.event.inputs.app }}",
-            "version": "${{ github.event.inputs.version }}"
+            "ref": "refs/tags/${{ github.event.inputs.app }}@${{ github.event.inputs.version }}",
+            "imageTag": "${{ github.event.inputs.version }}"
           }
         ]
       container-registry: ghcr.io


### PR DESCRIPTION
## Why did you create this PR

- We cannot publish dev Docker images for now

## What did you do

- @saenyakorn changes
  - Filter `//` from `affectedPackages`
- @bombnp changes
  - Add field `ref` and `imageTag` to specify which ref to checkout and what tag to tag the docker image
  - Transform publishedPackages to packagesToBuild to use with docker build workflow
  - Remove `latest` tag since we don't use it at all (better to not have it than have it be incorrect)

