### PR TITLE
Wait for userStore to initialize before prompting Google One Tap

### DIFF
--- a/.changeset/spotty-apples-invent.md
+++ b/.changeset/spotty-apples-invent.md
@@ -1,0 +1,5 @@
+---
+'web': patch
+---
+
+Wait for userStore to initialize before prompting Google One Tap

--- a/apps/web/src/common/components/GoogleOneTapPrompt/hooks/useGoogleOneTap/index.ts
+++ b/apps/web/src/common/components/GoogleOneTapPrompt/hooks/useGoogleOneTap/index.ts
@@ -23,8 +23,8 @@ export function useGoogleOneTap(promptRef: React.RefObject<HTMLDivElement>) {
   }, [promptRef.current])
 
   useEffect(() => {
-    if (isInitialized && !userStore.isLoggedIn()) {
+    if (isInitialized && userStore.isInitialized && !userStore.isLoggedIn()) {
       window.google?.accounts.id.prompt()
     }
-  }, [isInitialized, userStore.accessToken])
+  }, [isInitialized, userStore.accessToken, userStore.isInitialized])
 }

--- a/apps/web/src/store/userStore.ts
+++ b/apps/web/src/store/userStore.ts
@@ -5,7 +5,7 @@ import { apiUrl, httpClient } from '@web/services/httpClient'
 import { courseCartStore } from '@web/store'
 
 class UserStore {
-  private isInitialized = false
+  isInitialized = false
   accessToken: string | null
 
   constructor() {


### PR DESCRIPTION
## Why did you create this PR
Related to Google One Tap,
- > the prompt still pops up even if I'm logged in. Is there a way to make the prompt not appear if logged in?

## What did you do

- Wait for `userStore` to initialize before prompting Google One Tap

<!--
## Related links
-
-->
