### PR TITLE
Retain console.log in non-production environments

### DIFF
--- a/.changeset/light-badgers-boil.md
+++ b/.changeset/light-badgers-boil.md
@@ -1,0 +1,6 @@
+---
+'admin-web': patch
+'web': patch
+---
+
+Retain console.log in non-production environments

--- a/apps/admin-web/next.config.js
+++ b/apps/admin-web/next.config.js
@@ -1,10 +1,12 @@
 const path = require('path')
 
+const isProd = process.env.NODE_ENV !== 'development'
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   productionBrowserSourceMaps: true,
   compiler: {
-    removeConsole: {
+    removeConsole: isProd && {
       exclude: ['error', 'warn'],
     },
   },

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -5,6 +5,8 @@ const path = require('path')
 //   enabled: process.env.ANALYZE === 'true',
 // })
 
+const isProd = process.env.NODE_ENV !== 'development'
+
 /**
  * @type {import('next').NextConfig}
  */
@@ -14,7 +16,7 @@ const nextConfig = {
   //   IS_PULL_REQUEST: process.env.IS_PULL_REQUEST,
   // },
   compiler: {
-    removeConsole: {
+    removeConsole: isProd && {
       exclude: ['error', 'warn'],
     },
   },
@@ -23,7 +25,7 @@ const nextConfig = {
     return config
   },
   async rewrites() {
-    if (process.env.NODE_ENV !== 'development') return []
+    if (isProd) return []
     return [
       {
         source: '/apiProxy/:path*',


### PR DESCRIPTION
## Why did you create this PR
The next config was set to remove all console.log statements, which could make debugging difficult.

## What did you do
Disabled the removal in dev server, and only enable it in the build output.
