### PR TITLE
[Feat] Add update GitOps repository workflow

### DIFF
--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -73,6 +73,7 @@ jobs:
 
       - name: Cache Docker layers
         uses: actions/cache@v2
+        if: steps.check-dockerfile.outputs.DOCKERFILE_EXISTS == 'true'
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -120,16 +121,10 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
       - name: Move Docker cache
+        if: steps.check-dockerfile.outputs.DOCKERFILE_EXISTS == 'true'
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-
-      - name: Print Debug
-        run: |
-          echo "update = ${{ inputs.update }}"
-          echo "push = ${{ inputs.push }}"
-          echo "packages = ${{ inputs.packages }}"
-          echo "environment = ${{ inputs.environment }}"
 
   update-gitops:
     needs: build-and-publish-docker-image

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -7,6 +7,10 @@ on:
         description: Packages to build and publish
         required: true
         type: string
+      environment:
+        description: Environment to build and publish e.g. prod, beta, dev
+        required: true
+        type: string
       container-registry:
         description: Container registry to push the image to
         default: ghcr.io
@@ -14,34 +18,26 @@ on:
       image-prefix:
         description: Image prefix of the built image
         type: string
-      username:
-        description: Username for logging in to the container registry
-        type: string
-        default: ${{ github.actor }}
-      password:
-        description: Password for logging in to the container registry
-        type: string
-        default: ${{ github.token }}
-      target-repository:
+      target-gitops-repository:
         description: Target repository for updating deployment declaration
         type: string
         default: ${{ github.repository }}
-      target-ref:
+      target-gitops-ref:
         description: Target ref for updating deployment declaration
         type: string
-        default: main
-      target-directory:
-        description: Target directory for updating deployment declaration
-        type: string
-        default: .
+        default: ref/heads/master
       push:
         description: Enable pushing the image to the container registry
         type: boolean
-        default: false
+        default: true
       update:
         description: Enable updating deployment declaration in the target repository
         type: boolean
-        default: false
+        default: true
+    secrets:
+      GH_TOKEN:
+        description: GitHub token used to checkout target repository and open PR
+        required: true
 
 jobs:
   build-and-publish-docker-image:
@@ -55,6 +51,7 @@ jobs:
 
     outputs:
       DOCKERFILE_EXISTS: ${{ steps.check-dockerfile.outputs.DOCKERFILE_EXISTS }}
+      ENVIRONMENT: ${{ steps.get-deploy-environment.outputs.ENVIRONMENT }}
 
     steps:
       - name: Checkout with tags
@@ -83,8 +80,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ${{ inputs.container-registry }}
-          username: ${{ inputs.username || github.actor }}
-          password: ${{ inputs.password || github.token }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
 
       - name: Set frontend env
         if: ${{ matrix.packages.name == 'web' || matrix.packages.name == 'admin-web' }}
@@ -109,48 +106,21 @@ jobs:
         with:
           context: .
           file: apps/${{ matrix.packages.name }}/Dockerfile
-          tags: |
-            ${{ inputs.container-registry }}/${{ inputs.image-prefix }}/${{ matrix.packages.name }}:${{ matrix.packages.imageTag }}
+          tags: ${{ inputs.container-registry }}/${{ inputs.image-prefix }}/${{ matrix.packages.name }}:${{ matrix.packages.imageTag }}
           push: ${{ inputs.push }}
 
-  # update-deployment-declaration:
-  #   name: Update deployment declaration
+  update-gitops:
+    needs: build-and-publish-docker-image
 
-  #   if: ${{ inputs.update && needs.build-and-publish-docker-image.outputs.DOCKERFILE_EXISTS == 'true' }}
+    if: inputs.update == 'true'
 
-  #   needs:
-  #     - build-and-publish-docker-image
-
-  #   runs-on: ubuntu-latest
-
-  #   steps:
-  #     - name: Checkout Repo
-  #       uses: actions/checkout@v3
-  #       with:
-  #         repository: ${{ inputs.target-repository }}
-  #         ref: ${{ inputs.target-ref }}
-
-  #     - name: Update publishPackages version in YAML file
-  #       run: |
-  #         for row in $(echo "$PACKAGES" | jq -r '.[] | @base64'); do
-  #           _jq() {
-  #             echo ${row} | base64 --decode | jq -r ${1}
-  #           }
-  #           NAME=$(_jq '.name')
-  #           VERSION=$(_jq '.version')
-  #           OLD_VERSION=${{ inputs.container-registry }}\/${{ inputs.image-prefix }}\/$NAME:.*
-  #           NEW_VERSION=${{ inputs.container-registry }}\/${{ inputs.image-prefix }}\/$NAME:$VERSION
-  #           find ./${{ inputs.target-directory }} -type f -exec sed -i -e "s|$OLD_VERSION|$NEW_VERSION|g" {} \;
-  #           echo "${NAME}:${VERSION} is updated"
-  #         done
-  #       env:
-  #         PACKAGES: ${{ inputs.packages }}
-
-  #     - name: Show git status
-  #       run: git status
-
-  #     - name: Open Pull Request to the target repository
-  #       uses: peter-evans/create-pull-request@v4
-  #       with:
-  #         title: Update Package versions
-  #         commit-message: Update Package versions
+    uses: ./.github/workflows/update-gitops.yaml
+    with:
+      packages: ${{ inputs.packages }}
+      environment: ${{ inputs.environment }}
+      image-prefix: ${{ inputs.image-prefix }}
+      gitops-repository: ${{ inputs.target-gitops-repository }}
+      gitops-ref: ${{ inputs.target-gitops-ref }}
+      container-registry: ${{ inputs.container-registry }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -55,7 +55,6 @@ jobs:
 
     outputs:
       DOCKERFILE_EXISTS: ${{ steps.check-dockerfile.outputs.DOCKERFILE_EXISTS }}
-      ENVIRONMENT: ${{ steps.get-deploy-environment.outputs.ENVIRONMENT }}
 
     steps:
       - name: Checkout with tags
@@ -74,15 +73,6 @@ jobs:
             echo "Dockerfile exists"
             echo "DOCKERFILE_EXISTS=true" >> $GITHUB_OUTPUT
           fi
-
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        if: steps.check-dockerfile.outputs.DOCKERFILE_EXISTS == 'true'
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
 
       - name: Set up Docker Buildx
         if: steps.check-dockerfile.outputs.DOCKERFILE_EXISTS == 'true'
@@ -121,14 +111,8 @@ jobs:
           file: apps/${{ matrix.packages.name }}/Dockerfile
           tags: ${{ inputs.container-registry }}/${{ inputs.image-prefix }}/${{ matrix.packages.name }}:${{ matrix.packages.imageTag }}
           push: ${{ inputs.push }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      - name: Move Docker cache
-        if: steps.check-dockerfile.outputs.DOCKERFILE_EXISTS == 'true'
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   update-gitops:
     needs: build-and-publish-docker-image

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -26,6 +26,10 @@ on:
         description: Target ref for updating deployment declaration
         type: string
         default: ref/heads/master
+      gitops-mode:
+        description: Mode of updating deployment declaration, pr or commit
+        type: string
+        default: pr
       push:
         description: Enable pushing the image to the container registry
         type: boolean
@@ -139,5 +143,6 @@ jobs:
       gitops-repository: ${{ inputs.target-gitops-repository }}
       gitops-ref: ${{ inputs.target-gitops-ref }}
       container-registry: ${{ inputs.container-registry }}
+      gitops-mode: ${{ inputs.gitops-mode }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -143,6 +143,6 @@ jobs:
       gitops-repository: ${{ inputs.target-gitops-repository }}
       gitops-ref: ${{ inputs.target-gitops-ref }}
       container-registry: ${{ inputs.container-registry }}
-      gitops-mode: ${{ inputs.gitops-mode }}
+      mode: ${{ inputs.gitops-mode }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -71,6 +71,14 @@ jobs:
             echo "DOCKERFILE_EXISTS=true" >> $GITHUB_OUTPUT
           fi
 
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+
       - name: Set up Docker Buildx
         if: steps.check-dockerfile.outputs.DOCKERFILE_EXISTS == 'true'
         uses: docker/setup-buildx-action@v2
@@ -108,11 +116,25 @@ jobs:
           file: apps/${{ matrix.packages.name }}/Dockerfile
           tags: ${{ inputs.container-registry }}/${{ inputs.image-prefix }}/${{ matrix.packages.name }}:${{ matrix.packages.imageTag }}
           push: ${{ inputs.push }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      - name: Move Docker cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+
+      - name: Print Debug
+        run: |
+          echo "update = ${{ inputs.update }}"
+          echo "push = ${{ inputs.push }}"
+          echo "packages = ${{ inputs.packages }}"
+          echo "environment = ${{ inputs.environment }}"
 
   update-gitops:
     needs: build-and-publish-docker-image
 
-    if: inputs.update == 'true'
+    if: ${{ inputs.update == 'true' }}
 
     uses: ./.github/workflows/update-gitops.yaml
     with:

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -134,7 +134,7 @@ jobs:
   update-gitops:
     needs: build-and-publish-docker-image
 
-    if: ${{ inputs.update == 'true' }}
+    if: inputs.update
 
     uses: ./.github/workflows/update-gitops.yaml
     with:

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -26,7 +26,7 @@ on:
         description: Target ref for updating deployment declaration
         type: string
         default: ref/heads/master
-      gitops-mode:
+      update-mode:
         description: Mode of updating deployment declaration, pr or commit
         type: string
         default: pr
@@ -143,6 +143,6 @@ jobs:
       gitops-repository: ${{ inputs.target-gitops-repository }}
       gitops-ref: ${{ inputs.target-gitops-ref }}
       container-registry: ${{ inputs.container-registry }}
-      mode: ${{ inputs.gitops-mode }}
+      mode: ${{ inputs.update-mode }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -35,6 +35,7 @@ jobs:
 
     outputs:
       affectedPackages: ${{ steps.affected-packages.outputs.affectPackages }}
+      environment: ${{ steps.get-deploy-environment.outputs.ENVIRONMENT }}
 
     steps:
       - name: Checkout Repo
@@ -73,6 +74,20 @@ jobs:
           echo "affectPackages=$PACKAGES_OUTPUT" >> $GITHUB_OUTPUT
           echo "affectPackages=$PACKAGES_OUTPUT"
 
+      - name: Get deploy environment
+        id: get-deploy-environment
+        run: |
+          if [[ ${{ github.ref_name  }} == "main" ]]; then
+            echo "Deploy environment is production"
+            echo "ENVIRONMENT=prod" >> $GITHUB_OUTPUT
+          elif [[ ${{ github.ref_name  }} == "beta" ]]; then
+            echo "Deploy environment is beta"
+            echo "ENVIRONMENT=beta" >> $GITHUB_OUTPUT
+          elif [[ ${{ github.ref_name  }} == "dev" ]]; then
+            echo "Deploy environment is dev"
+            echo "ENVIRONMENT=dev" >> $GITHUB_OUTPUT
+          fi
+
       - name: Print Debug
         run: echo "${{ steps.affected-packages.outputs.affectPackages }}"
 
@@ -82,6 +97,7 @@ jobs:
     uses: ./.github/workflows/deploy-docker.yaml
     with:
       packages: ${{ needs.release.outputs.affectedPackages }}
+      environment: ${{ needs.release.outputs.environment }}
       container-registry: ghcr.io
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -69,8 +69,7 @@ jobs:
         id: affected-packages
         run: |
           PACKAGES='${{ steps.affected-apps.outputs.packages }}'
-          TAG=${{ github.ref_name }}-${{ github.sha }}
-          PACKAGES_OUTPUT=$(echo $PACKAGES | jq -c 'map_values({name:.,ref:"refs/heads/dev",imageTag:"$TAG"})')
+          PACKAGES_OUTPUT=$(echo $PACKAGES | jq -c 'map_values({name:.,ref:"refs/heads/${{ github.ref_name }}",imageTag:"${{ github.ref_name }}-${{ github.sha }}"})')
           echo "affectPackages=$PACKAGES_OUTPUT" >> $GITHUB_OUTPUT
           echo "affectPackages=$PACKAGES_OUTPUT"
 

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -100,6 +100,6 @@ jobs:
       container-registry: ghcr.io
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops
-      target-gitops-ref: refs/heads/main
+      target-gitops-ref: refs/heads/master
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -22,7 +22,7 @@ permissions:
 
 jobs:
   release:
-    name: Release dev
+    name: Release without versioning
 
     strategy:
       matrix:
@@ -68,7 +68,8 @@ jobs:
         id: affected-packages
         run: |
           PACKAGES='${{ steps.affected-apps.outputs.packages }}'
-          PACKAGES_OUTPUT=$(echo $PACKAGES | jq -c 'map_values({name:.,ref:"refs/heads/dev",imageTag:"dev"})')
+          TAG=${{ github.ref_name }}-${{ github.sha }}
+          PACKAGES_OUTPUT=$(echo $PACKAGES | jq -c 'map_values({name:.,ref:"refs/heads/dev",imageTag:"$TAG"})')
           echo "affectPackages=$PACKAGES_OUTPUT" >> $GITHUB_OUTPUT
           echo "affectPackages=$PACKAGES_OUTPUT"
 
@@ -83,10 +84,7 @@ jobs:
       packages: ${{ needs.release.outputs.affectedPackages }}
       container-registry: ghcr.io
       image-prefix: thinc-org/cugetreg
-      username: ${{ github.actor }}
-      password: ${{ github.token }}
-      # target-repository: ${{ github.repository }}
-      # target-ref: main
-      # target-directory: k8s-demo
-      push: true
-      update: false
+      target-gitops-repository: thinc-org/cugetreg-gitops
+      target-gitops-ref: refs/heads/main
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -101,6 +101,6 @@ jobs:
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops
       target-gitops-ref: refs/heads/master
-      mode: commit
+      gitops-mode: commit
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -101,6 +101,6 @@ jobs:
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops
       target-gitops-ref: refs/heads/master
-      gitops-mode: commit
+      update-mode: commit
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -101,5 +101,6 @@ jobs:
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops
       target-gitops-ref: refs/heads/master
+      mode: commit
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release-dev.yaml
+++ b/.github/workflows/release-dev.yaml
@@ -87,9 +87,6 @@ jobs:
             echo "ENVIRONMENT=dev" >> $GITHUB_OUTPUT
           fi
 
-      - name: Print Debug
-        run: echo "${{ steps.affected-packages.outputs.affectPackages }}"
-
   deploy-with-docker:
     needs:
       - release

--- a/.github/workflows/release-without-versioning.yaml
+++ b/.github/workflows/release-without-versioning.yaml
@@ -1,4 +1,4 @@
-name: Release - Dev
+name: Release without versioning
 
 on:
   push:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,14 @@ on:
       version:
         description: 'The version to release. The version should be the same as version in package.json. For example, 1.0.0'
         required: true
+      environment:
+        type: choice
+        description: 'The environment to release. The name should be the same as name in package.json'
+        required: true
+        options:
+          - prod
+          - beta
+          - dev
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -155,7 +163,7 @@ jobs:
             "imageTag": "${{ github.event.inputs.version }}"
           }
         ]
-      environment: ${{ needs.release.outputs.environment }}
+      environment: ${{ github.event.inputs.environment }}
       container-registry: ghcr.io
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -138,7 +138,7 @@ jobs:
       container-registry: ghcr.io
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops
-      target-gitops-ref: refs/heads/main
+      target-gitops-ref: refs/heads/master
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -158,6 +158,6 @@ jobs:
       container-registry: ghcr.io
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops
-      target-gitops-ref: refs/heads/main
+      target-gitops-ref: refs/heads/master
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -134,6 +134,7 @@ jobs:
     uses: ./.github/workflows/deploy-docker.yaml
     with:
       packages: ${{ needs.release.outputs.transformedPackages }}
+      environment: ${{ needs.release.outputs.environment }}
       container-registry: ghcr.io
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops
@@ -153,6 +154,7 @@ jobs:
             "imageTag": "${{ github.event.inputs.version }}"
           }
         ]
+      environment: ${{ needs.release.outputs.environment }}
       container-registry: ghcr.io
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,7 +139,7 @@ jobs:
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops
       target-gitops-ref: refs/heads/master
-      gitops-mode: pr
+      update-mode: pr
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -160,6 +160,6 @@ jobs:
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops
       target-gitops-ref: refs/heads/master
-      gitops-mode: pr
+      update-mode: pr
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,6 +139,7 @@ jobs:
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops
       target-gitops-ref: refs/heads/master
+      mode: pr
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -159,5 +160,6 @@ jobs:
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops
       target-gitops-ref: refs/heads/master
+      mode: pr
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,8 @@ jobs:
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
       hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
       pullRequestNumber: ${{ steps.changesets.outputs.pullRequestNumber }}
+      environment: ${{ steps.get-deploy-environment.outputs.ENVIRONMENT }}
+      transformedPackages: ${{ steps.transform-packages.outputs.packages }}
 
     steps:
       - name: Checkout Repo
@@ -103,6 +105,20 @@ jobs:
           PACKAGES=$(echo ${{ steps.changesets.outputs.publishedPackages }} | jq -c 'map_values({name:.name,ref:"refs/tags/"+.version,imageTag:.version})')
           echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
 
+      - name: Get deploy environment
+        id: get-deploy-environment
+        run: |
+          if [[ ${{ github.ref_name  }} == "main" ]]; then
+            echo "Deploy environment is production"
+            echo "ENVIRONMENT=prod" >> $GITHUB_OUTPUT
+          elif [[ ${{ github.ref_name  }} == "beta" ]]; then
+            echo "Deploy environment is beta"
+            echo "ENVIRONMENT=beta" >> $GITHUB_OUTPUT
+          elif [[ ${{ github.ref_name  }} == "dev" ]]; then
+            echo "Deploy environment is dev"
+            echo "ENVIRONMENT=dev" >> $GITHUB_OUTPUT
+          fi
+
       - name: Echo Changeset output
         run: |
           echo "Changeset published - ${{ steps.changesets.outputs.published }}"
@@ -117,16 +133,13 @@ jobs:
     if: ${{ needs.release.outputs.published == 'true' }}
     uses: ./.github/workflows/deploy-docker.yaml
     with:
-      packages: ${{ needs.release.outputs.publishedPackages }}
+      packages: ${{ needs.release.outputs.transformedPackages }}
       container-registry: ghcr.io
       image-prefix: thinc-org/cugetreg
-      username: ${{ github.actor }}
-      password: ${{ github.token }}
-      # target-repository: ${{ github.repository }}
-      # target-ref: main
-      # target-directory: k8s-demo
-      push: true
-      update: false
+      target-gitops-repository: thinc-org/cugetreg-gitops
+      target-gitops-ref: refs/heads/main
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
   deploy-with-docker-dispatch:
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -142,10 +155,7 @@ jobs:
         ]
       container-registry: ghcr.io
       image-prefix: thinc-org/cugetreg
-      username: ${{ github.actor }}
-      password: ${{ github.token }}
-      # target-repository: ${{ github.repository }}
-      # target-ref: refs/tags/${{ github.event.inputs.app }}@${{ github.event.inputs.version }}
-      # target-directory: k8s-demo
-      push: true
-      update: false
+      target-gitops-repository: thinc-org/cugetreg-gitops
+      target-gitops-ref: refs/heads/main
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -110,7 +110,7 @@ jobs:
       - name: Transform Packages
         id: transform-packages
         run: |
-          PACKAGES=$(echo ${{ steps.changesets.outputs.publishedPackages }} | jq -c 'map_values({name:.name,ref:"refs/tags/"+.version,imageTag:.version})')
+          PACKAGES=$(echo ${{ steps.changesets.outputs.publishedPackages }} | jq -c 'map_values({name:.name,ref:"refs/tags/\(.version)",imageTag:.version})')
           echo "packages=$PACKAGES" >> $GITHUB_OUTPUT
 
       - name: Get deploy environment

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -139,7 +139,7 @@ jobs:
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops
       target-gitops-ref: refs/heads/master
-      mode: pr
+      gitops-mode: pr
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -160,6 +160,6 @@ jobs:
       image-prefix: thinc-org/cugetreg
       target-gitops-repository: thinc-org/cugetreg-gitops
       target-gitops-ref: refs/heads/master
-      mode: pr
+      gitops-mode: pr
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/update-gitops.yaml
+++ b/.github/workflows/update-gitops.yaml
@@ -97,4 +97,4 @@ jobs:
 
             ## Updated Packages
 
-            ${{ steps.pr-body.outputs.UPDATED_PACKAGES }}
+            ${{ env.UPDATED_PACKAGES }}

--- a/.github/workflows/update-gitops.yaml
+++ b/.github/workflows/update-gitops.yaml
@@ -63,7 +63,7 @@ jobs:
             }
             NAME=$(_jq '.name')
             IMAGE_TAG=$(_jq '.imageTag')
-            PREFIX=${{ inputs.container-registry }}/${{ inputs.image-prefix }}}
+            PREFIX=${{ inputs.container-registry }}/${{ inputs.image-prefix }}
             bash -c "cd $NAME/overlays/${{ inputs.environment }} && kustomize edit set image $NAME=$PREFIX/$NAME:$IMAGE_TAG"
             echo "${NAME}:${IMAGE_TAG} is updated"
           done

--- a/.github/workflows/update-gitops.yaml
+++ b/.github/workflows/update-gitops.yaml
@@ -35,7 +35,9 @@ on:
 jobs:
   update-gitops:
     name: Update GitOps and Open PR
+
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/update-gitops.yaml
+++ b/.github/workflows/update-gitops.yaml
@@ -73,7 +73,10 @@ jobs:
         id: pr-body
         run: |
           echo "DATE=$(date +'%d/%m/%Y')" >> $GITHUB_OUTPUT
-          echo "UPDATED_PACKAGES=$(echo "$PACKAGES" | jq -r '.[] | "- \(.name): \(.imageTag)"')" >> $GITHUB_OUTPUT
+          UPDATED_PACKAGES=$(echo "$PACKAGES" | jq -r '.[] | "- \(.name): \(.imageTag)"')
+          echo "UPDATED_PACKAGES<<EOF" >> $GITHUB_ENV
+          echo "$UPDATED_PACKAGES" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
         env:
           PACKAGES: ${{ inputs.packages }}
 

--- a/.github/workflows/update-gitops.yaml
+++ b/.github/workflows/update-gitops.yaml
@@ -1,0 +1,95 @@
+name: Update GitOps and Open PR
+
+on:
+  workflow_call:
+    inputs:
+      packages:
+        description: 'Packages to update'
+        required: true
+        type: string
+      environment:
+        description: 'Environment e.g. beta, prod, main used to define path to kustomize overlay'
+        required: true
+        type: string
+      image-prefix:
+        description: 'Prefix of image e.g. thinc-org/cugetreg'
+        required: true
+        type: string
+      gitops-repository:
+        description: 'Target GitOps repository'
+        required: true
+        type: string
+      gitops-ref:
+        description: 'Target GitOps ref'
+        type: string
+        default: refs/heads/master
+      container-registry:
+        description: 'Container registry e.g. ghcr.io'
+        type: string
+        default: ghcr.io
+    secrets:
+      GH_TOKEN:
+        description: 'GitHub token used to checkout GitOps repository and open PR'
+        required: true
+
+jobs:
+  update-gitops:
+    name: Update GitOps and Open PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ inputs.gitops-repository }}
+          ref: ${{ inputs.gitops-ref }}
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Setup Kustomize
+        uses: multani/action-setup-kustomize@v1
+        with:
+          version: 5.0.0
+
+      - name: Update kustomize configuration
+        run: |
+          for row in $(echo "$PACKAGES" | jq -r '.[] | @base64'); do
+            _jq() {
+              echo ${row} | base64 --decode | jq -r ${1}
+            }
+            NAME=$(_jq '.name')
+            IMAGE_TAG=$(_jq '.imageTag')
+            PREFIX=${{ inputs.container-registry }}/${{ inputs.image-prefix }}}
+            bash -c "cd $NAME/overlays/${{ inputs.environment }} && kustomize edit set image $NAME=$PREFIX/$NAME:$IMAGE_TAG"
+            echo "${NAME}:${IMAGE_TAG} is updated"
+          done
+        env:
+          PACKAGES: ${{ inputs.packages }}
+
+      - name: Show Git Status
+        run: git status
+
+      - name: Prepare Pull Request body
+        id: pr-body
+        run: |
+          echo "DATE=$(date +'%d/%m/%Y')" >> $GITHUB_OUTPUT
+          echo "UPDATED_PACKAGES=$(echo "$PACKAGES" | jq -r '.[] | "- \(.name): \(.imageTag)"')" >> $GITHUB_OUTPUT
+        env:
+          PACKAGES: ${{ inputs.packages }}
+
+      - name: Create Pull Request to GitOps
+        uses: peter-evans/create-pull-request@v4
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+          commit-message: update gitops
+          branch: update-gitops/master
+          base: master
+          title: Update GitOps
+          body: |
+            # Update GitOps
+
+            Date ${{ steps.pr-body.outputs.DATE }}
+
+            > This PR is automatically generated
+
+            ## Updated Packages
+
+            ${{ steps.pr-body.outputs.UPDATED_PACKAGES }}

--- a/.github/workflows/update-gitops.yaml
+++ b/.github/workflows/update-gitops.yaml
@@ -27,6 +27,10 @@ on:
         description: 'Container registry e.g. ghcr.io'
         type: string
         default: ghcr.io
+      mode:
+        description: 'Mode of the action, pr or commit'
+        type: string
+        default: pr
     secrets:
       GH_TOKEN:
         description: 'GitHub token used to checkout GitOps repository and open PR'
@@ -82,6 +86,7 @@ jobs:
 
       - name: Create Pull Request to GitOps
         uses: peter-evans/create-pull-request@v4
+        if: ${{ inputs.mode == 'pr' }}
         with:
           token: ${{ secrets.GH_TOKEN }}
           commit-message: update gitops
@@ -98,3 +103,9 @@ jobs:
             ## Updated Packages
 
             ${{ env.UPDATED_PACKAGES }}
+
+      - name: Add, commit and push to the repository
+        uses: stefanzweifel/git-auto-commit-action@v4
+        if: ${{ inputs.mode == 'commit' }}
+        with:
+          commit_message: Update GitOps

--- a/.github/workflows/update-gitops.yaml
+++ b/.github/workflows/update-gitops.yaml
@@ -1,4 +1,4 @@
-name: Update GitOps and Open PR
+name: Update GitOps repository
 
 on:
   workflow_call:

--- a/.github/workflows/update-gitops.yaml
+++ b/.github/workflows/update-gitops.yaml
@@ -75,6 +75,7 @@ jobs:
 
       - name: Prepare Pull Request body
         id: pr-body
+        if: ${{ inputs.mode == 'pr' }}
         run: |
           echo "DATE=$(date +'%d/%m/%Y')" >> $GITHUB_OUTPUT
           UPDATED_PACKAGES=$(echo "$PACKAGES" | jq -r '.[] | "- \(.name): \(.imageTag)"')


### PR DESCRIPTION
## Why did you create this PR

-

## What did you do

- Add `update-gitops.yaml` workflow for open PR to cugetreg-gitops repo
- Add `gitops-mode` to choose between `PR` or `commit` 

## Workflow explain 
- When we push something to to `dev`, the action will calculate affected packages and push kustomize changed to gitios repo.
- When we push something to `beta`, the action will do pre-release thing, and then open the Pre-release PR. After we merge the PR, the action will bump the package version, build the docker images and open kustomize changed PR to GitOps repo.
- Similar to `beta`, when we push something to `main`, the action will do release thing, and the rest is the same as `beta`'s flow. 

## Demo

Workflow https://github.com/thinc-org/cugetreg/actions/runs/4106806503

Success Commit - https://github.com/thinc-org/cugetreg-gitops/commit/ac296cee9f9ada87fc91369eda675950bbcbd62f

Success opened PR - https://github.com/thinc-org/cugetreg-gitops/pull/6 

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
