### PR TITLE
Hotfix typo in Google One Tap ITP config

### DIFF
--- a/.changeset/long-seals-clean.md
+++ b/.changeset/long-seals-clean.md
@@ -1,0 +1,5 @@
+---
+'web': patch
+---
+
+Correct typo in Google One Tap ITP config

--- a/apps/web/src/common/components/GoogleOneTapPrompt/hooks/useGoogleOneTap/index.ts
+++ b/apps/web/src/common/components/GoogleOneTapPrompt/hooks/useGoogleOneTap/index.ts
@@ -4,6 +4,10 @@ import { useEffect, useState } from 'react'
 import { GOOGLE_OAUTH_ID } from '@web/env'
 import { userStore } from '@web/store/userStore'
 
+interface ExtendedIdConfiguration extends IdConfiguration {
+  hosted_domain: string // hosted_domain is undocumented in the official documentation
+}
+
 export function useGoogleOneTap(promptRef: React.RefObject<HTMLDivElement>) {
   const [isInitialized, setIsInitialized] = useState(false)
 
@@ -16,11 +20,11 @@ export function useGoogleOneTap(promptRef: React.RefObject<HTMLDivElement>) {
         userStore.loginWithIdToken(response.credential)
       },
       auto_select: true,
-      itp_supported: false,
+      itp_support: false,
       cancel_on_tap_outside: false,
       prompt_parent_id: promptRef.current.id,
-      hosted_domain: 'student.chula.ac.th', // hosted_domain is undocumented in the official documentation
-    } as IdConfiguration)
+      hosted_domain: 'student.chula.ac.th',
+    } satisfies ExtendedIdConfiguration as IdConfiguration)
     setIsInitialized(true)
   }, [promptRef.current])
 


### PR DESCRIPTION
## Why did you create this PR

As mentioned in #501, the Google One Tap should not be prompted on ITP browsers. However, a typo was made in the config param, making it still prompt.
- Correct: `itp_support`
- Wrong: `itp_supported`

The TypeScript type check does not catch this error due to the entire config object was cast to `IdConfiguration` to add support for the undocumented `hosted_domain` param.

## What did you do

- Correct the typo
- Extend the `IdConfiguration` type to add the `hosted_domain` param to allow type checking, before casting it back to `IdConfiguration`.
 
Any better solution is welcome.