### PR TITLE
[Fix] Add more conditions for setup frontend env 

### DIFF
--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -87,20 +87,23 @@ jobs:
           password: ${{ github.token }}
 
       - name: Set frontend env
-        if: ${{ matrix.packages.name == 'web' || matrix.packages.name == 'admin-web' }}
+        if: ${{ contains(fromJson('["web", "admin-wb"]'), matrix.packages.name) && steps.check-dockerfile.outputs.DOCKERFILE_EXISTS == 'true' }}
         env:
           APP_NAME: ${{ matrix.packages.name }}
           BRANCH: ${{ github.ref_name }}
         run: |
           if [[ $BRANCH == 'main' ]]; then
-            echo "$APP_NAME env is set to production"
-            mv apps/$APP_NAME/.env.prod apps/$APP_NAME/.env
+            [ ! -d "apps/$APP_NAME/.env.prod" ] && echo "$APP_NAME production env not found"
+            [ -d "apps/$APP_NAME/.env.prod" ] && echo "$APP_NAME env is set to production"
+            [ -d "apps/$APP_NAME/.env.prod" ] && mv apps/$APP_NAME/.env.prod apps/$APP_NAME/.env
           elif [[ $BRANCH == 'beta' ]]; then
-            echo "$APP_NAME env is set to dev"
-            mv apps/$APP_NAME/.env.beta apps/$APP_NAME/.env
+            [ ! -d "apps/$APP_NAME/.env.beta" ] && echo "$APP_NAME beta env not found"
+            [ -d "apps/$APP_NAME/.env.beta" ] && echo "$APP_NAME env is set to dev"
+            [ -d "apps/$APP_NAME/.env.beta" ] && mv apps/$APP_NAME/.env.beta apps/$APP_NAME/.env
           elif [[ $BRANCH == 'dev' ]]; then
-            echo "$APP_NAME env is set to beta"
-            mv apps/$APP_NAME/.env.dev apps/$APP_NAME/.env
+            [ ! -d "apps/$APP_NAME/.env.dev" ] && echo "$APP_NAME dev env not found"
+            [ -d "apps/$APP_NAME/.env.dev" ] && echo "$APP_NAME env is set to beta"
+            [ -d "apps/$APP_NAME/.env.dev" ] && mv apps/$APP_NAME/.env.dev apps/$APP_NAME/.env
           fi
 
       - name: Build and push Docker image

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -87,7 +87,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Set frontend env
-        if: ${{ contains(fromJson('["web", "admin-wb"]'), matrix.packages.name) && steps.check-dockerfile.outputs.DOCKERFILE_EXISTS == 'true' }}
+        if: ${{ contains(fromJson('["web", "admin-web"]'), matrix.packages.name) && steps.check-dockerfile.outputs.DOCKERFILE_EXISTS == 'true' }}
         env:
           APP_NAME: ${{ matrix.packages.name }}
           BRANCH: ${{ github.ref_name }}


### PR DESCRIPTION
## Why did you create this PR

- Because this error https://github.com/thinc-org/cugetreg/actions/runs/4157069395, if we don't have environment-specific env. It should use `.env` or nothing instead.

## What did you do

- Check if file exists before move `.env`

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
