### PR TITLE
Fix frontend env check in workflow

### DIFF
--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -101,6 +101,8 @@ jobs:
           elif [[ $BRANCH == 'dev' && -f "apps/$APP_NAME/.env.dev" ]]; then
             mv apps/$APP_NAME/.env.dev apps/$APP_NAME/.env
             echo "$APP_NAME env is set to dev"
+          else
+            echo "$APP_NAME env is not set. This could be because branch '$BRANCH' is not in [main, beta, dev] or .env file for the branch is not found"
           fi
 
       - name: Build and push Docker image

--- a/.github/workflows/deploy-docker.yaml
+++ b/.github/workflows/deploy-docker.yaml
@@ -92,18 +92,15 @@ jobs:
           APP_NAME: ${{ matrix.packages.name }}
           BRANCH: ${{ github.ref_name }}
         run: |
-          if [[ $BRANCH == 'main' ]]; then
-            [ ! -d "apps/$APP_NAME/.env.prod" ] && echo "$APP_NAME production env not found"
-            [ -d "apps/$APP_NAME/.env.prod" ] && echo "$APP_NAME env is set to production"
-            [ -d "apps/$APP_NAME/.env.prod" ] && mv apps/$APP_NAME/.env.prod apps/$APP_NAME/.env
-          elif [[ $BRANCH == 'beta' ]]; then
-            [ ! -d "apps/$APP_NAME/.env.beta" ] && echo "$APP_NAME beta env not found"
-            [ -d "apps/$APP_NAME/.env.beta" ] && echo "$APP_NAME env is set to dev"
-            [ -d "apps/$APP_NAME/.env.beta" ] && mv apps/$APP_NAME/.env.beta apps/$APP_NAME/.env
-          elif [[ $BRANCH == 'dev' ]]; then
-            [ ! -d "apps/$APP_NAME/.env.dev" ] && echo "$APP_NAME dev env not found"
-            [ -d "apps/$APP_NAME/.env.dev" ] && echo "$APP_NAME env is set to beta"
-            [ -d "apps/$APP_NAME/.env.dev" ] && mv apps/$APP_NAME/.env.dev apps/$APP_NAME/.env
+          if [[ $BRANCH == 'main' && -f "apps/$APP_NAME/.env.prod" ]]; then
+            mv apps/$APP_NAME/.env.prod apps/$APP_NAME/.env
+            echo "$APP_NAME env is set to production"
+          elif [[ $BRANCH == 'beta' && -f "apps/$APP_NAME/.env.beta" ]]; then
+            mv apps/$APP_NAME/.env.beta apps/$APP_NAME/.env
+            echo "$APP_NAME env is set to beta"
+          elif [[ $BRANCH == 'dev' && -f "apps/$APP_NAME/.env.dev" ]]; then
+            mv apps/$APP_NAME/.env.dev apps/$APP_NAME/.env
+            echo "$APP_NAME env is set to dev"
           fi
 
       - name: Build and push Docker image


### PR DESCRIPTION
## Why did you create this PR
- Currently, when frontend checks for frontend env files, it uses "-d", but it should be "-f".
- Also, when -f errors outside if condition (returns non-zero value), it seems to just fail the run totally.

## What did you do
- Use "-f" instead of "-d"
- Move condition to if condition block

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
