### PR TITLE
Include .prettierrc.js during web build

### DIFF
--- a/.changeset/weak-oranges-exist.md
+++ b/.changeset/weak-oranges-exist.md
@@ -1,0 +1,5 @@
+---
+"web": patch
+---
+
+Include .prettierrc.js during web build

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -37,6 +37,7 @@ COPY pnpm-lock.yaml ./pnpm-lock.yaml
 RUN pnpm install --frozen-lockfile
 
 COPY --from=pruner /app/out/full/ .
+COPY --from=pruner /app/.prettierrc.js ./.prettierrc.js
 COPY turbo.json turbo.json
 RUN pnpm turbo run build --filter=web...
 


### PR DESCRIPTION
## Why did you create this PR
- `web` is failing to build due to missing `.prettierrc.js` during build

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
