### PR TITLE
disable linting during nextjs builds

### DIFF
--- a/apps/admin-web/next.config.js
+++ b/apps/admin-web/next.config.js
@@ -16,6 +16,9 @@ const nextConfig = {
   experimental: {
     outputFileTracingRoot: path.join(__dirname, '../../'),
   },
+  eslint: {
+    ignoreDuringBuilds: true,
+  }
 }
 
 module.exports = nextConfig

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -37,7 +37,6 @@ COPY pnpm-lock.yaml ./pnpm-lock.yaml
 RUN pnpm install --frozen-lockfile
 
 COPY --from=pruner /app/out/full/ .
-COPY --from=pruner /app/.prettierrc.js ./.prettierrc.js
 COPY turbo.json turbo.json
 RUN pnpm turbo run build --filter=web...
 

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -38,6 +38,9 @@ const nextConfig = {
     outputFileTracingRoot: path.join(__dirname, '../../'),
     transpilePackages: ['@cgr/course-utils', '@cgr/codegen'],
   },
+  eslint: {
+    ignoreDuringBuilds: true,
+  }
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
## Why did you create this PR
- Next.js lints before building by default, which cause build to fail if .prettierrc.js is not present.

## What did you do
- Disable linting during Next.js builds
- Reverts #542 

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
