### PR TITLE
Use gitops-update-mode as "commit" for beta deployments

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,8 @@ jobs:
       publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
       hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
       pullRequestNumber: ${{ steps.changesets.outputs.pullRequestNumber }}
-      environment: ${{ steps.get-deploy-environment.outputs.ENVIRONMENT }}
+      environment: ${{ steps.get-deploy-metadata.outputs.environment }}
+      gitOpsUpdateMode: ${{ steps.get-deploy-metadata.outputs.gitOpsUpdateMode }}
       transformedPackages: ${{ steps.transform-packages.outputs.packages }}
 
     steps:
@@ -115,18 +116,21 @@ jobs:
         env:
           PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
 
-      - name: Get deploy environment
-        id: get-deploy-environment
+      - name: Get deploy metadata
+        id: get-deploy-metadata
         run: |
           if [[ ${{ github.ref_name  }} == "main" ]]; then
             echo "Deploy environment is production"
-            echo "ENVIRONMENT=prod" >> $GITHUB_OUTPUT
+            echo "environment=prod" >> $GITHUB_OUTPUT
+            echo "gitOpsUpdateMode=pr" >> $GITHUB_OUTPUT
           elif [[ ${{ github.ref_name  }} == "beta" ]]; then
             echo "Deploy environment is beta"
-            echo "ENVIRONMENT=beta" >> $GITHUB_OUTPUT
+            echo "environment=beta" >> $GITHUB_OUTPUT
+            echo "gitOpsUpdateMode=commit" >> $GITHUB_OUTPUT
           elif [[ ${{ github.ref_name  }} == "dev" ]]; then
             echo "Deploy environment is dev"
-            echo "ENVIRONMENT=dev" >> $GITHUB_OUTPUT
+            echo "environment=dev" >> $GITHUB_OUTPUT
+            echo "gitOpsUpdateMode=commit" >> $GITHUB_OUTPUT
           fi
 
       - name: Echo Changeset output
@@ -149,7 +153,7 @@ jobs:
       image-prefix: thinc-org/cugetreg
       gitops-repository: thinc-org/cugetreg-gitops
       gitops-ref: master
-      update-mode: pr
+      update-mode: ${{ needs.release.outputs.gitOpsUpdateMode }}
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 


### PR DESCRIPTION
## Why did you create this PR
- "GitOps update mode" determines how it should update gitops manifest files in gitops repo. Currently, main and beta uses "pr" to update the repo, while dev uses "commit". It is annoying for developers who want to deploy beta to ask infra to deploy beta every time, as beta is supposed to be used for testing anyways.

## What did you do
- Use update mode "commit" instead of "pr" for beta deployments
  - When merging "Version Packages (beta)" PRs, it should automatically deploy to gitops.

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
