### PR TITLE
chore: remove nx from .vscode/extensions.json

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "nrwl.angular-console",
     "esbenp.prettier-vscode",
     "firsttris.vscode-jest-runner",
     "dbaeumer.vscode-eslint"


### PR DESCRIPTION
## Why did you create this PR

We no longer use nx

## What did you do

Stop recommending nx extensions
