### PR TITLE
Fix scraper missing course description

### DIFF
--- a/.changeset/eighty-carrots-ring.md
+++ b/.changeset/eighty-carrots-ring.md
@@ -1,0 +1,5 @@
+---
+'@cgr/schema': patch
+---
+
+add course descriptions to course schema

--- a/.changeset/thick-otters-accept.md
+++ b/.changeset/thick-otters-accept.md
@@ -1,0 +1,5 @@
+---
+'reg-scraper': patch
+---
+
+exit on scrape if scraper is in progress to prevent infinitely stuck scraper

--- a/apps/reg-scraper/src/scraper/scraper.service.ts
+++ b/apps/reg-scraper/src/scraper/scraper.service.ts
@@ -33,9 +33,9 @@ export class ScraperService {
     const start = new Date()
     if (this.isScraping) {
       this.logger.error(
-        'Received attempt to scrape via scheduler while already in progress. Rejected.'
+        'Received attempt to scrape via scheduler while already in progress. Exiting...'
       )
-      return
+      process.exit(1)
     }
     this.isScraping = true
 

--- a/packages/schema/src/mongo/course.schema.ts
+++ b/packages/schema/src/mongo/course.schema.ts
@@ -114,6 +114,8 @@ export const CourseSchema = new Schema({
   semester: { type: String, required: true, enum: semesters },
   academicYear: { type: String, required: true },
   courseNo: { type: String, required: true },
+  courseDescTh: { type: String },
+  courseDescEn: { type: String },
   abbrName: { type: String, required: true },
   courseNameTh: { type: String, required: true },
   courseNameEn: { type: String, required: true },


### PR DESCRIPTION
## Why did you create this PR

- Course descriptions was missing from website, due to missing fields in mongo schema (oops)

## What did you do

- Add `courseDescTh` and courseDescEn` fields back
- Also introduce a temporary workaround for infinitely stuck scraper problem by exiting on rescrape if a scrape in is progress

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [ ] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
