### PR TITLE
Fix term selector out of sync

### DIFF
--- a/.changeset/big-tomatoes-sleep.md
+++ b/.changeset/big-tomatoes-sleep.md
@@ -1,0 +1,5 @@
+---
+'web': patch
+---
+
+Fix term selector out of sync

--- a/apps/web/src/modules/CourseSearch/index.tsx
+++ b/apps/web/src/modules/CourseSearch/index.tsx
@@ -49,7 +49,7 @@ export function CourseSearchPage() {
         <MuiStack direction="row" spacing={2} alignItems="center">
           <Typography variant="h2">ค้นหาวิชาเรียน</Typography>
           {isSmUp && (
-            <Select defaultValue={`${academicYear}/${semester}`} onChange={handleChange}>
+            <Select value={`${academicYear}/${semester}`} onChange={handleChange}>
               {termOptions.map(({ academicYear, semester, label }) => (
                 <MenuItem key={`${academicYear}/${semester}`} value={`${academicYear}/${semester}`}>
                   {label}


### PR DESCRIPTION
## Why did you create this PR

- When changing term from top bar, term selector next to "ค้นหาวิขาเรียน" will go out of sync.

![image](https://github.com/thinc-org/cugetreg/assets/30551284/09b8926f-04af-42cf-8933-d01fcf0d5cac)

## What did you do

- Fix it

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [x] Deploy a demo
- [x] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
