### PR TITLE
fix: TBA null - null

### DIFF
--- a/.changeset/dry-trainers-knock.md
+++ b/.changeset/dry-trainers-knock.md
@@ -1,0 +1,5 @@
+---
+'web': patch
+---
+
+fix empty exam date display

--- a/apps/web/src/common/utils/getExamPeriod/index.ts
+++ b/apps/web/src/common/utils/getExamPeriod/index.ts
@@ -26,7 +26,7 @@ export function getFinalExamPeriod(scheduleClass: ExamClass | Course) {
 }
 
 export function getFormattedExamPeriod(period: Period | undefined | null) {
-  if (!period) {
+  if (!period || !period.start || !period.end) {
     return 'TBA'
   }
   return `${period.start} - ${period.end}`

--- a/apps/web/src/modules/CourseDetail/index.tsx
+++ b/apps/web/src/modules/CourseDetail/index.tsx
@@ -166,13 +166,13 @@ export function CourseDetailPage({ course, reviews, ogImageUrl }: CourseDetailPa
         <Grid item xs={12} sm={6}>
           <DescriptionTitle variant="subtitle1">สอบกลางภาค</DescriptionTitle>
           <Typography variant="h6">
-            {course.midterm ? `${midtermDate} ${midtermPeriod}` : 'TBA'}
+            {course.midterm?.date ? `${midtermDate} ${midtermPeriod}` : 'TBA'}
           </Typography>
         </Grid>
         <GridEnd item xs={12} sm={6}>
           <DescriptionTitle variant="subtitle1">สอบปลายภาค</DescriptionTitle>
           <Typography variant="h6">
-            {course.final ? `${finalDate} ${finalPeriod}` : 'TBA'}
+            {course.final?.date ? `${finalDate} ${finalPeriod}` : 'TBA'}
           </Typography>
         </GridEnd>
         <Grid item xs={12} sm={12}>

--- a/apps/web/src/modules/Schedule/components/CourseDialog/components/CourseDialogDetail.tsx
+++ b/apps/web/src/modules/Schedule/components/CourseDialog/components/CourseDialogDetail.tsx
@@ -93,13 +93,13 @@ export function CourseDialogDetail() {
         <Stack spacing={0.5}>
           <Caption>{t('midtermExam')}</Caption>
           <Typography variant="subtitle1">
-            {midtermPeriod} {midtermDate}
+            {item.midterm?.date ? `${midtermDate} ${midtermPeriod}` : 'TBA'}
           </Typography>
         </Stack>
         <Stack spacing={0.5}>
           <Caption>{t('finalExam')}</Caption>
           <Typography variant="subtitle1">
-            {finalPeriod} {finalDate}
+            {item.final?.date ? `${midtermDate} ${midtermPeriod}` : 'TBA'}
           </Typography>
         </Stack>
       </Stack>


### PR DESCRIPTION
## Why did you create this PR

- because TBA null - null, due to some graphql lib changes which always populates field midterm and final as
```
midterm: {
  date: null
  period: {
    start: null
    start: null
  }
}
```
instead of 
```
midterm: null
```

## What did you do

- fix the conditions in dialog page and course detail page

test in dev before merge

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [x] Deploy a demo
- [ ] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
