### PR TITLE
Fix midterm exam date displays as final exam

### DIFF
--- a/.changeset/dry-crabs-thank.md
+++ b/.changeset/dry-crabs-thank.md
@@ -1,0 +1,5 @@
+---
+'web': patch
+---
+
+Fix midterm exam date displays as final exam

--- a/apps/web/src/modules/Schedule/components/CourseDialog/components/CourseDialogDetail.tsx
+++ b/apps/web/src/modules/Schedule/components/CourseDialog/components/CourseDialogDetail.tsx
@@ -99,7 +99,7 @@ export function CourseDialogDetail() {
         <Stack spacing={0.5}>
           <Caption>{t('finalExam')}</Caption>
           <Typography variant="subtitle1">
-            {item.final?.date ? `${midtermDate} ${midtermPeriod}` : 'TBA'}
+            {item.final?.date ? `${finalDate} ${finalPeriod}` : 'TBA'}
           </Typography>
         </Stack>
       </Stack>


### PR DESCRIPTION
## Why did you create this PR

- So, I was experimenting with using `gpt-3.5-turbo` to review code changes. It appears that it catches a mistake in #602.

## What did you do

- Fix the component to display final exam date and period in final exam slot

## Demo

[https://dev.cugetreg.com](https://dev.cugetreg.com)

## Checklist

- [x] Deploy a demo
- [x] Check browsers compatibility
- [ ] Wrote coverage tests

<!--
## Related links
-
-->
