### PR TITLE
Hook an error logging for 404 course

### DIFF
--- a/apps/api/src/course/course.service.ts
+++ b/apps/api/src/course/course.service.ts
@@ -29,7 +29,7 @@ export class CourseService {
     })
 
     if (!course) {
-      throw new NotFoundError("Can't find a course with the given parameters")
+      throw new NotFoundError(`Can't find a course with the given parameters ${JSON.stringify({courseNo, semester, academicYear, studyProgram})}`)
     }
     return course
   }

--- a/apps/web/src/modules/CourseDetail/index.tsx
+++ b/apps/web/src/modules/CourseDetail/index.tsx
@@ -246,6 +246,7 @@ export async function getServerSideProps(
     }
   } catch (e) {
     if (e instanceof ApolloError) {
+      console.warn(`CourseDetail not found query=${JSON.stringify(context.query)}`, e)
       return {
         notFound: true,
       }


### PR DESCRIPTION
## Why did you create this PR

- There's an elevated error rate for Course Detail endpoint since 2022Q3

## What did you do

- Add logging to see what kind of path was taken

## Demo

No Demo. Tested on local.

## Checklist

- [ ] ~Deploy a demo~
- [ ] ~Check browsers compatibility~
- [ ] ~Wrote coverage tests~

<!--
## Related links
-
-->
