### PR TITLE
fix: remove duplicate offset in get course schema

### DIFF
--- a/apps/core/src/zod_schemas/courses.schema.ts
+++ b/apps/core/src/zod_schemas/courses.schema.ts
@@ -28,7 +28,6 @@ export const getCourseQuerySchema = z.object({
   assessment: z.enum(assessment).optional(),
   sortBy: z.enum(sortBy).optional(),
   sortOrder: z.enum(sortOrder).optional(),
-  offset: z.coerce.number().int().optional(),
   limit: z.coerce.number().int().optional(),
   offset: z.coerce.number().int().optional(),
 });


### PR DESCRIPTION
## Why did you create this PR

- fix get courses schema
 
## What did you do

- remove duplicate offset in `getCourseQuerySchema`
