### PR TITLE
Fix: Comment show semester and year

### DIFF
--- a/apps/cugetreg/src/routes/course-page/[courseId]/+page.svelte
+++ b/apps/cugetreg/src/routes/course-page/[courseId]/+page.svelte
@@ -1245,7 +1245,7 @@
                 {#each pagedReviews as review, index (index)}
                   <Comment
                     rating={review.rating / 2}
-                    semester={review.semester as 'FIRST' | 'SECOND' | 'SUMMER'}
+                    semester={SEMESTER_LABEL_LONG[review.semester]}
                     year={review.academicYear}
                     content={review.content}
                     likesCount={review.stats.likeCount}

--- a/apps/cugetreg/src/routes/course-page/[courseId]/+page.svelte
+++ b/apps/cugetreg/src/routes/course-page/[courseId]/+page.svelte
@@ -1246,6 +1246,7 @@
                   <Comment
                     rating={review.rating / 2}
                     semester={review.semester as 'FIRST' | 'SECOND' | 'SUMMER'}
+                    year={review.academicYear}
                     content={review.content}
                     likesCount={review.stats.likeCount}
                     dislikesCount={review.stats.dislikeCount}

--- a/packages/ui/src/lib/components/molecules/comment/comment.svelte
+++ b/packages/ui/src/lib/components/molecules/comment/comment.svelte
@@ -10,7 +10,7 @@
 	interface CommentProps {
 		content: string;
 		semester: string;
-        year: number;
+		year: number;
 		rating: number;
 		likesCount: number;
 		dislikesCount: number;
@@ -27,7 +27,7 @@
 	let {
 		content,
 		semester,
-        year,
+		year,
 		rating,
 		likesCount,
 		dislikesCount,
@@ -95,7 +95,8 @@
 			<RatingStar {rating} />
 
 			<div class="text-subtitle font-sans font-medium">
-				{semester} {year}
+				{semester}
+				{year}
 			</div>
 		</div>
 

--- a/packages/ui/src/lib/components/molecules/comment/comment.svelte
+++ b/packages/ui/src/lib/components/molecules/comment/comment.svelte
@@ -10,6 +10,7 @@
 	interface CommentProps {
 		content: string;
 		semester: string;
+		year: number;
 		rating: number;
 		likesCount: number;
 		dislikesCount: number;
@@ -26,6 +27,7 @@
 	let {
 		content,
 		semester,
+		year,
 		rating,
 		likesCount,
 		dislikesCount,
@@ -73,6 +75,11 @@
 			ALLOWED_ATTR: ['href']
 		})
 	);
+	const SEMESTER_TO_TEXT: Record<string, string> = {
+		FIRST: 'ภาคต้น',
+		SECOND: 'ภาคปลาย',
+		SUMMER: 'ภาคฤดูร้อน'
+	};
 </script>
 
 <div
@@ -93,7 +100,8 @@
 			<RatingStar {rating} />
 
 			<div class="text-subtitle font-sans font-medium">
-				{semester}
+				{SEMESTER_TO_TEXT[semester]}
+				{year}
 			</div>
 		</div>
 

--- a/packages/ui/src/lib/components/molecules/comment/comment.svelte
+++ b/packages/ui/src/lib/components/molecules/comment/comment.svelte
@@ -10,7 +10,7 @@
 	interface CommentProps {
 		content: string;
 		semester: string;
-		year: number;
+        year: number;
 		rating: number;
 		likesCount: number;
 		dislikesCount: number;
@@ -27,7 +27,7 @@
 	let {
 		content,
 		semester,
-		year,
+        year,
 		rating,
 		likesCount,
 		dislikesCount,
@@ -75,11 +75,6 @@
 			ALLOWED_ATTR: ['href']
 		})
 	);
-	const SEMESTER_TO_TEXT: Record<string, string> = {
-		FIRST: 'ภาคต้น',
-		SECOND: 'ภาคปลาย',
-		SUMMER: 'ภาคฤดูร้อน'
-	};
 </script>
 
 <div
@@ -100,8 +95,7 @@
 			<RatingStar {rating} />
 
 			<div class="text-subtitle font-sans font-medium">
-				{SEMESTER_TO_TEXT[semester]}
-				{year}
+				{semester} {year}
 			</div>
 		</div>
 


### PR DESCRIPTION
## Why did you create this PR

- Fix the comment to show semester in Thai and Academic year.

## What did you do

- Edit comment props to handle year.
- Map semester to Thai

## Demo

<img width="1293" height="748" alt="image" src="https://github.com/user-attachments/assets/3aa73265-dbd9-48e5-8d7d-2e93cc93a388" />

