### PR TITLE
Feat: extends timetable days and end time.

### DIFF
--- a/apps/cugetreg/src/lib/components/exams-list.svelte
+++ b/apps/cugetreg/src/lib/components/exams-list.svelte
@@ -2,7 +2,10 @@
   import {
     getExamData,
     getExamDateOrder,
+    getLatestExamTime,
     isExamConflicted,
+    TIMETABLE_DEFAULT_END,
+    TIMETABLE_DEFAULT_START,
   } from '$lib/utils/schedule';
 
   import {
@@ -42,6 +45,19 @@
 
   const examsData = $derived(getExamData(cart, exams));
   const examDateOrder = $derived(getExamDateOrder(examsData));
+
+  const midtermExams = $derived(
+    examDateOrder.midterms.flatMap((key) => examsData.midterms[key] ?? []),
+  );
+  const finalExams = $derived(
+    examDateOrder.finals.flatMap((key) => examsData.finals[key] ?? []),
+  );
+  const midtermEndTime = $derived(
+    getLatestExamTime(midtermExams, TIMETABLE_DEFAULT_END),
+  );
+  const finalEndTime = $derived(
+    getLatestExamTime(finalExams, TIMETABLE_DEFAULT_END),
+  );
 </script>
 
 <div class="flex flex-row items-center justify-between lg:justify-center">
@@ -108,7 +124,8 @@
   >
     <div class="min-w-150">
       <TimeTable
-        startTime={7}
+        startTime={TIMETABLE_DEFAULT_START}
+        periodPerDay={midtermEndTime - TIMETABLE_DEFAULT_START}
         days={examDateOrder.midterms
           .filter((time) => time !== 0)
           .map((time) => formatDate(new Date(time)))}
@@ -125,7 +142,8 @@
                   room: '',
                   section: 0,
                 }}
-                col={formatExamColumn(exam.start ?? undefined) - 7}
+                col={formatExamColumn(exam.start ?? undefined) -
+                  TIMETABLE_DEFAULT_START}
                 row={index}
                 length={exam.duration}
                 color={exam.colorVariant}
@@ -146,7 +164,8 @@
   >
     <div class="min-w-150">
       <TimeTable
-        startTime={7}
+        startTime={TIMETABLE_DEFAULT_START}
+        periodPerDay={finalEndTime - TIMETABLE_DEFAULT_START}
         days={examDateOrder.finals
           .filter((time) => time !== 0)
           .map((time) => formatDate(new Date(time)))}
@@ -163,7 +182,8 @@
                   room: '',
                   section: 0,
                 }}
-                col={formatExamColumn(examCourse.start ?? undefined) - 7}
+                col={formatExamColumn(examCourse.start ?? undefined) -
+                  TIMETABLE_DEFAULT_START}
                 row={index}
                 length={examCourse.duration}
                 color={examCourse.colorVariant}

--- a/apps/cugetreg/src/lib/components/timetable-block-group.svelte
+++ b/apps/cugetreg/src/lib/components/timetable-block-group.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { getColumnFromDay } from '$lib/mapper';
-  import { isConflicted, parsePeriodTime } from '$lib/utils/schedule';
+  import {
+    isConflicted,
+    parsePeriodTime,
+    TIMETABLE_DEFAULT_START,
+  } from '$lib/utils/schedule';
 
   import { TimetableCourseCard } from '@cugetreg/ui/atoms/timetable';
   import type { ColorVariant, Day } from '@cugetreg/utils/types';
@@ -42,7 +46,7 @@
         length={parsePeriodTime(period.periodEnd) -
           parsePeriodTime(period.periodStart)}
         row={getColumnFromDay(period.dayOfWeek as Day)}
-        col={parsePeriodTime(period.periodStart) - 7}
+        col={parsePeriodTime(period.periodStart) - TIMETABLE_DEFAULT_START}
       />
     {/if}
   {/each}

--- a/apps/cugetreg/src/lib/utils/schedule.ts
+++ b/apps/cugetreg/src/lib/utils/schedule.ts
@@ -306,3 +306,16 @@ export function getLatestTime(
 
   return Math.ceil(latest);
 }
+
+export function getLatestExamTime(
+  exams: ExamData[],
+  fallbackTime: number,
+): number {
+  const latest = exams.reduce((acc, exam) => {
+    if (!exam.end) return acc;
+    const endTime = exam.end.getHours() + exam.end.getMinutes() / 60;
+    return endTime > acc ? endTime : acc;
+  }, fallbackTime);
+
+  return Math.ceil(latest);
+}

--- a/apps/cugetreg/src/lib/utils/schedule.ts
+++ b/apps/cugetreg/src/lib/utils/schedule.ts
@@ -4,13 +4,14 @@ import { type ViewCourseData } from '@cugetreg/ui/organisms/view-course';
 import { discardTime, formatDate, formatExamTime } from '@cugetreg/utils';
 import type { ColorVariant } from '@cugetreg/utils/types';
 import type {
-  CartData,
-  CartItemDetail,
   CartItemDetailBase,
   CartWithItemsBase,
   ExamScheduleItem,
   Period,
 } from '@cugetreg/zod-schemas';
+
+export const TIMETABLE_DEFAULT_START = 7;
+export const TIMETABLE_DEFAULT_END = 19;
 
 export type ExamData = {
   abbrName: string;
@@ -271,6 +272,8 @@ export function getDays(cart: CartItemDetailBase[]) {
   const WEEKENDS = ['SAT', 'SUN'];
 
   const hasWeekend = cart.some((item) => {
+    if (item.hidden) return false;
+
     const section = item.sections.find(
       (sec) => sec.sectionNo === item.sectionNo,
     );
@@ -282,8 +285,12 @@ export function getDays(cart: CartItemDetailBase[]) {
   return [...WEEKDAYS, ...(hasWeekend ? WEEKENDS : [])];
 }
 
-export function getLatestTime(cart: CartItemDetailBase[], min: number): number {
-  return cart.reduce((acc, item) => {
+export function getLatestTime(
+  cart: CartItemDetailBase[],
+  fallbackTime: number,
+): number {
+  const latest = cart.reduce((acc, item) => {
+    if (item.hidden) return acc;
     const section = item.sections.find(
       (sec) => sec.sectionNo === item.sectionNo,
     );
@@ -295,5 +302,7 @@ export function getLatestTime(cart: CartItemDetailBase[], min: number): number {
       }, acc) ?? 0;
 
     return localMax > acc ? localMax : acc;
-  }, min);
+  }, fallbackTime);
+
+  return Math.ceil(latest);
 }

--- a/apps/cugetreg/src/lib/utils/schedule.ts
+++ b/apps/cugetreg/src/lib/utils/schedule.ts
@@ -4,6 +4,8 @@ import { type ViewCourseData } from '@cugetreg/ui/organisms/view-course';
 import { discardTime, formatDate, formatExamTime } from '@cugetreg/utils';
 import type { ColorVariant } from '@cugetreg/utils/types';
 import type {
+  CartData,
+  CartItemDetail,
   CartItemDetailBase,
   CartWithItemsBase,
   ExamScheduleItem,
@@ -262,4 +264,36 @@ export async function createElementScreenshot(
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
+}
+
+export function getDays(cart: CartItemDetailBase[]) {
+  const WEEKDAYS = ['MON', 'TUE', 'WED', 'THU', 'FRI'];
+  const WEEKENDS = ['SAT', 'SUN'];
+
+  const hasWeekend = cart.some((item) => {
+    const section = item.sections.find(
+      (sec) => sec.sectionNo === item.sectionNo,
+    );
+    return section?.classes.some(
+      (cls) => cls.dayOfWeek === 'SA' || cls.dayOfWeek === 'SU',
+    );
+  });
+
+  return [...WEEKDAYS, ...(hasWeekend ? WEEKENDS : [])];
+}
+
+export function getLatestTime(cart: CartItemDetailBase[], min: number): number {
+  return cart.reduce((acc, item) => {
+    const section = item.sections.find(
+      (sec) => sec.sectionNo === item.sectionNo,
+    );
+
+    const localMax =
+      section?.classes.reduce((accMin, period) => {
+        const periodTime = parsePeriodTime(period.periodEnd);
+        return periodTime > accMin ? periodTime : accMin;
+      }, acc) ?? 0;
+
+    return localMax > acc ? localMax : acc;
+  }, min);
 }

--- a/apps/cugetreg/src/routes/schedule/+page.svelte
+++ b/apps/cugetreg/src/routes/schedule/+page.svelte
@@ -20,6 +20,8 @@
     getDays,
     getLatestTime,
     getViewCourseData,
+    TIMETABLE_DEFAULT_END,
+    TIMETABLE_DEFAULT_START,
   } from '$lib/utils/schedule';
 
   import { BookMarked, Loader2, Menu } from '@lucide/svelte';
@@ -101,7 +103,7 @@
 
   const scheduleDays = $derived(getDays($userCart.currentCart.items));
   const scheduleEndTime = $derived(
-    getLatestTime($userCart.currentCart.items, 19),
+    getLatestTime($userCart.currentCart.items, TIMETABLE_DEFAULT_END),
   );
 
   $effect(() => {
@@ -367,8 +369,8 @@
           >
             <div class="min-w-150">
               <Timetable
-                startTime={7}
-                periodPerDay={scheduleEndTime - 7}
+                startTime={TIMETABLE_DEFAULT_START}
+                periodPerDay={scheduleEndTime - TIMETABLE_DEFAULT_START}
                 days={scheduleDays}
               >
                 {#each $userCart.currentCart?.items as course (course.id)}

--- a/apps/cugetreg/src/routes/schedule/+page.svelte
+++ b/apps/cugetreg/src/routes/schedule/+page.svelte
@@ -17,6 +17,8 @@
   import {
     calculateCredit,
     createElementScreenshot,
+    getDays,
+    getLatestTime,
     getViewCourseData,
   } from '$lib/utils/schedule';
 
@@ -95,6 +97,11 @@
     browser
       ? `${window.location.host}/schedule/${$userCart.currentCart.id}`
       : '',
+  );
+
+  const scheduleDays = $derived(getDays($userCart.currentCart.items));
+  const scheduleEndTime = $derived(
+    getLatestTime($userCart.currentCart.items, 19),
   );
 
   $effect(() => {
@@ -359,7 +366,11 @@
             bind:this={scheduleTableRef}
           >
             <div class="min-w-150">
-              <Timetable startTime={7}>
+              <Timetable
+                startTime={7}
+                periodPerDay={scheduleEndTime - 7}
+                days={scheduleDays}
+              >
                 {#each $userCart.currentCart?.items as course (course.id)}
                   <TimetableBlockGroup
                     {course}

--- a/apps/cugetreg/src/routes/schedule/[slug]/+page.svelte
+++ b/apps/cugetreg/src/routes/schedule/[slug]/+page.svelte
@@ -8,6 +8,10 @@
   import {
     calculateCredit,
     createElementScreenshot,
+    getDays,
+    getLatestTime,
+    TIMETABLE_DEFAULT_END,
+    TIMETABLE_DEFAULT_START,
   } from '$lib/utils/schedule';
 
   import { Eye, Info } from '@lucide/svelte';
@@ -40,11 +44,17 @@
   let timetableDiv = $state<HTMLElement | undefined>();
   let innerWidth = $state(1024);
 
+  // TODO: Add this
   let _selectedCartItemId = $state<string | undefined>(undefined);
 
   let scheduleTableRef = $state<HTMLElement | null>(null);
 
   // ================ DERIVED ================
+
+  const scheduleDays = $derived(getDays(cart.items));
+  const scheduleEndTime = $derived(
+    getLatestTime(cart.items, TIMETABLE_DEFAULT_END),
+  );
 
   const totalCredit = $derived(calculateCredit(cart.items));
 
@@ -90,7 +100,6 @@
             </div>
 
             <div class="flex items-end gap-4">
-              <!-- TODO: Add student ID, currently not in API -->
               <span class="text-button2 shrink-0">โดย {owner}</span>
 
               <YearSemesterChip
@@ -131,7 +140,11 @@
           bind:this={scheduleTableRef}
         >
           <div class="min-w-150">
-            <Timetable startTime={7}>
+            <Timetable
+              startTime={TIMETABLE_DEFAULT_START}
+              periodPerDay={scheduleEndTime - TIMETABLE_DEFAULT_START}
+              days={scheduleDays}
+            >
               {#each cart.items as course (course.id)}
                 <TimetableBlockGroup {course} cartItems={cart.items} />
               {/each}


### PR DESCRIPTION
## Why did you create this PR

- Add weekends to timetable if there's any course in weekends.
- Extend the timetable if course end time exceed default end time.
- Extend exam schedule if any exam is outside default end time.

## What did you do

- Remove magic number (7: `TIMETABLE_DEFAULT_START`)
- Add `getDays` and `getLatestTime` for adapting timetable.
- Extend timetable for public and private schedule.
- Add `getLatestExamTime` for adapting exam schedule.

## Demo

<img width="1290" height="699" alt="image" src="https://github.com/user-attachments/assets/4c389b52-6856-4bf0-b47a-38c71d6aa149" />
<img width="1253" height="1010" alt="image" src="https://github.com/user-attachments/assets/f055e4d6-5eca-4eea-8524-62992893529f" />
<img width="846" height="1198" alt="image" src="https://github.com/user-attachments/assets/06ffaae1-a1e9-4e66-b9aa-e0cecfbd8157" />

