### PR TITLE
feat: announcement endpoints and activity CRUD

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
     "source.organizeImports": "never"
   },
   "npm.packageManager": "pnpm",
+  "eslint.workingDirectories": [{ "mode": "auto" }],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[typescript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/apps/core/prisma/migrations/20260712001850_add_announcement_activity/migration.sql
+++ b/apps/core/prisma/migrations/20260712001850_add_announcement_activity/migration.sql
@@ -1,0 +1,31 @@
+-- CreateTable
+CREATE TABLE "activity" (
+    "id" TEXT NOT NULL,
+    "cart_id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT NOT NULL,
+    "day_of_week" "day_of_week" NOT NULL,
+    "period_start" TEXT NOT NULL,
+    "period_end" TEXT NOT NULL,
+    "color" TEXT,
+    "hidden" BOOLEAN NOT NULL DEFAULT false,
+    "cart_order" TEXT NOT NULL DEFAULT '0|hzzzzz:',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "activity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "announcement" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "announcement_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "activity" ADD CONSTRAINT "activity_cart_id_fkey" FOREIGN KEY ("cart_id") REFERENCES "cart"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/core/prisma/schema.prisma
+++ b/apps/core/prisma/schema.prisma
@@ -297,6 +297,7 @@ model Cart {
 
   // Relations
   items CartItem[]
+  activities Activity[]
 
   @@map("cart")
 }
@@ -324,6 +325,29 @@ model CartItem {
   updatedAt DateTime @updatedAt @map("updated_at")
 
   @@map("cart_item")
+}
+
+model Activity {
+  id String @id @default(cuid())
+
+  cartId String @map("cart_id")
+  cart Cart @relation(fields: [cartId], references: [id])
+
+  title String @map("title")
+  description String @map("description")
+
+  dayOfWeek   DayOfWeek @map("day_of_week")
+  periodStart String    @map("period_start")
+  periodEnd   String    @map("period_end")
+
+  color     String?
+  hidden    Boolean @default(false)
+  cartOrder String @default("0|hzzzzz:") @map("cart_order")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@map("activity")
 }
 
 model Review {
@@ -369,6 +393,18 @@ model ReviewVote {
 
   @@map("review_votes")
   @@unique([userId,reviewId])
+}
+
+model Announcement {
+  id String @id @default(cuid())
+
+  title String @map("title")
+  content String @map("content")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  @@map("announcement")
 }
 
 model Session {

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -4,6 +4,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import dotenv from "dotenv";
 import { cors } from "hono/cors";
 
+import activity from "./routes/activity.js";
 import admin from "./routes/admin.js";
 import announcement from "./routes/announcement.js";
 import authRoute, { includeAuth, middlewareAuth } from "./routes/auth.js";
@@ -61,12 +62,14 @@ app.use("/courses/*", includeAuth);
 app.route("/courses", courses);
 
 // Middleware List
-app.use("/admin/*", middlewareAuth); // Middleware from Bearer Token
+app.use("/activity/*", middlewareAuth); // Middleware from Bearer Token
+app.use("/admin/*", middlewareAuth);
 app.use("/carts/*", middlewareAuth);
 app.use("/reviews/*", middlewareAuth);
 app.use("/user/*", middlewareAuth);
 
 // Protected routes (session injected by middlewareAuth above)
+app.route("/activity", activity);
 app.route("/admin", admin);
 app.route("/carts", carts);
 app.route("/reviews", reviews);

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -5,6 +5,7 @@ import dotenv from "dotenv";
 import { cors } from "hono/cors";
 
 import admin from "./routes/admin.js";
+import announcement from "./routes/announcement.js";
 import authRoute, { includeAuth, middlewareAuth } from "./routes/auth.js";
 import carts from "./routes/carts.js";
 import courses from "./routes/courses.js";
@@ -53,6 +54,7 @@ app.openAPIRegistry.registerComponent("securitySchemes", "CookieAuth", {
 // Public routes — no auth required
 app.route("/public/carts", publicCarts);
 app.route("/auth", authRoute);
+app.route("/announcement", announcement);
 
 app.use("/courses/*", includeAuth);
 

--- a/apps/core/src/routes/activity.ts
+++ b/apps/core/src/routes/activity.ts
@@ -1,0 +1,78 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+
+import type { Variables } from "../lib/auth.js";
+import {
+  createActivityRoute,
+  deleteActivityRoute,
+  updateActivityRoute,
+} from "../routes_define/activity.routes.js";
+import { activityService } from "../services/activityService.js";
+
+const activity = new OpenAPIHono<{ Variables: Variables }>()
+
+  .openapi(createActivityRoute, async (c) => {
+    try {
+      const userId = c.get("user").id;
+      const validatedData = c.req.valid("json");
+      const newActivity = await activityService.createActivity(
+        userId,
+        validatedData,
+      );
+      return c.json({ data: newActivity }, 201);
+    } catch (err) {
+      if (err instanceof Error) {
+        if (err.message === "CART_NOT_FOUND") {
+          return c.json({ error: "CART_NOT_FOUND" }, 404);
+        }
+        if (err.message === "NOT_CART_OWNER") {
+          return c.json({ error: "NOT_CART_OWNER" }, 403);
+        }
+      }
+      return c.json({ error: "INTERNAL_SERVER_ERROR" }, 500);
+    }
+  })
+
+  .openapi(updateActivityRoute, async (c) => {
+    try {
+      const userId = c.get("user").id;
+      const activityId = c.req.param("activityId");
+      const updatedData = c.req.valid("json");
+      const updatedActivity = await activityService.updateActivity(
+        userId,
+        activityId,
+        updatedData,
+      );
+      return c.json({ data: updatedActivity }, 200);
+    } catch (err) {
+      if (err instanceof Error) {
+        if (err.message === "ACTIVITY_NOT_FOUND") {
+          return c.json({ error: "ACTIVITY_NOT_FOUND" }, 404);
+        }
+        if (err.message === "NOT_CART_OWNER") {
+          return c.json({ error: "NOT_CART_OWNER" }, 403);
+        }
+      }
+      return c.json({ error: "INTERNAL_SERVER_ERROR" }, 500);
+    }
+  })
+
+  .openapi(deleteActivityRoute, async (c) => {
+    try {
+      const userId = c.get("user").id;
+      const activityId = c.req.param("activityId");
+      await activityService.deleteActivity(userId, activityId);
+      return c.body(null, 204);
+    } catch (err) {
+      if (err instanceof Error) {
+        if (err.message === "ACTIVITY_NOT_FOUND") {
+          return c.json({ error: "ACTIVITY_NOT_FOUND" }, 404);
+        }
+        if (err.message === "NOT_CART_OWNER") {
+          return c.json({ error: "NOT_CART_OWNER" }, 403);
+        }
+      }
+      return c.json({ error: "INTERNAL_SERVER_ERROR" }, 500);
+    }
+  });
+
+export default activity;

--- a/apps/core/src/routes/announcement.ts
+++ b/apps/core/src/routes/announcement.ts
@@ -1,0 +1,35 @@
+import { OpenAPIHono } from "@hono/zod-openapi";
+
+import {
+  getAnnouncementByIdRoute,
+  listAnnouncementsRoute,
+} from "../routes_define/announcement.routes.js";
+import { announcementService } from "../services/announcementService.js";
+
+const announcement = new OpenAPIHono();
+
+announcement
+  .openapi(listAnnouncementsRoute, async (c) => {
+    try {
+      const announcements = await announcementService.listAnnouncements();
+      return c.json({ data: announcements }, 200);
+    } catch {
+      return c.json({ error: "INTERNAL_SERVER_ERROR" }, 500);
+    }
+  })
+
+  .openapi(getAnnouncementByIdRoute, async (c) => {
+    try {
+      const { announcementId } = c.req.valid("param");
+      const found =
+        await announcementService.getAnnouncementById(announcementId);
+      return c.json({ data: found }, 200);
+    } catch (err) {
+      if (err instanceof Error && err.message === "ANNOUNCEMENT_NOT_FOUND") {
+        return c.json({ error: "ANNOUNCEMENT_NOT_FOUND" }, 404);
+      }
+      return c.json({ error: "INTERNAL_SERVER_ERROR" }, 500);
+    }
+  });
+
+export default announcement;

--- a/apps/core/src/routes_define/activity.routes.ts
+++ b/apps/core/src/routes_define/activity.routes.ts
@@ -1,0 +1,67 @@
+import { createRoute } from "@hono/zod-openapi";
+
+import {
+  ActivityIdParamSchema,
+  CreateActivityBodySchema,
+  UpdateActivityBodySchema,
+} from "@cugetreg/zod-schemas/activity";
+import { SingleActivityResponseSchema } from "@cugetreg/zod-schemas/activity-response";
+
+import { errorRes, InternalError } from "./errorRes.js";
+
+export const createActivityRoute = createRoute({
+  method: "post",
+  path: "/",
+  summary: "Create activity",
+  request: {
+    body: {
+      content: { "application/json": { schema: CreateActivityBodySchema } },
+    },
+  },
+  responses: {
+    201: {
+      content: { "application/json": { schema: SingleActivityResponseSchema } },
+      description: "Created",
+    },
+    403: errorRes("NOT_CART_OWNER"),
+    404: errorRes("CART_NOT_FOUND"),
+    500: InternalError,
+  },
+  security: [{ Bearer: [] }],
+});
+
+export const updateActivityRoute = createRoute({
+  method: "patch",
+  path: "/{activityId}",
+  summary: "Update activity",
+  request: {
+    params: ActivityIdParamSchema,
+    body: {
+      content: { "application/json": { schema: UpdateActivityBodySchema } },
+    },
+  },
+  responses: {
+    200: {
+      content: { "application/json": { schema: SingleActivityResponseSchema } },
+      description: "Updated",
+    },
+    403: errorRes("NOT_CART_OWNER"),
+    404: errorRes("ACTIVITY_NOT_FOUND"),
+    500: InternalError,
+  },
+  security: [{ Bearer: [] }],
+});
+
+export const deleteActivityRoute = createRoute({
+  method: "delete",
+  path: "/{activityId}",
+  summary: "Delete activity",
+  request: { params: ActivityIdParamSchema },
+  responses: {
+    204: { description: "Deleted" },
+    403: errorRes("NOT_CART_OWNER"),
+    404: errorRes("ACTIVITY_NOT_FOUND"),
+    500: InternalError,
+  },
+  security: [{ Bearer: [] }],
+});

--- a/apps/core/src/routes_define/announcement.routes.ts
+++ b/apps/core/src/routes_define/announcement.routes.ts
@@ -1,0 +1,41 @@
+import { createRoute } from "@hono/zod-openapi";
+
+import { AnnouncementIdParamSchema } from "@cugetreg/zod-schemas/announcement";
+import {
+  AnnouncementDetailResponseSchema,
+  ListAnnouncementsResponseSchema,
+} from "@cugetreg/zod-schemas/announcement-response";
+
+import { errorRes, InternalError } from "./errorRes.js";
+
+export const listAnnouncementsRoute = createRoute({
+  method: "get",
+  path: "/",
+  summary: "List announcements",
+  responses: {
+    200: {
+      content: {
+        "application/json": { schema: ListAnnouncementsResponseSchema },
+      },
+      description: "OK",
+    },
+    500: InternalError,
+  },
+});
+
+export const getAnnouncementByIdRoute = createRoute({
+  method: "get",
+  path: "/{announcementId}",
+  summary: "Get announcement detail",
+  request: { params: AnnouncementIdParamSchema },
+  responses: {
+    200: {
+      content: {
+        "application/json": { schema: AnnouncementDetailResponseSchema },
+      },
+      description: "OK",
+    },
+    404: errorRes("ANNOUNCEMENT_NOT_FOUND"),
+    500: InternalError,
+  },
+});

--- a/apps/core/src/services/activityService.ts
+++ b/apps/core/src/services/activityService.ts
@@ -1,0 +1,112 @@
+import type {
+  CreateActivityBodySchema,
+  UpdateActivityBodySchema,
+} from "@cugetreg/zod-schemas/activity";
+
+import { LexoRankService } from "./lexorank.service.js";
+
+import { prisma } from "../db/clients.js";
+import { mapDayOfWeek } from "../utils/enumMapper.js";
+
+export const activityService = {
+  createActivity: async (userId: string, data: CreateActivityBodySchema) => {
+    return prisma.$transaction(async (tx) => {
+      const cart = await tx.cart.findUnique({ where: { id: data.cartId } });
+
+      if (!cart) {
+        throw new Error("CART_NOT_FOUND");
+      }
+      if (cart.userId !== userId) {
+        throw new Error("NOT_CART_OWNER");
+      }
+
+      const lastActivity = await tx.activity.findFirst({
+        where: { cartId: data.cartId },
+        orderBy: { cartOrder: "desc" },
+      });
+
+      const nextOrder = LexoRankService.getNextRank(lastActivity?.cartOrder);
+
+      return tx.activity.create({
+        data: {
+          cartId: data.cartId,
+          title: data.title,
+          description: data.description,
+          dayOfWeek: mapDayOfWeek(data.dayOfWeek),
+          periodStart: data.periodStart,
+          periodEnd: data.periodEnd,
+          color: data.color,
+          hidden: data.hidden ?? false,
+          cartOrder: nextOrder,
+        },
+      });
+    });
+  },
+
+  updateActivity: async (
+    userId: string,
+    activityId: string,
+    updatedData: UpdateActivityBodySchema,
+  ) => {
+    return prisma.$transaction(async (tx) => {
+      const targetActivity = await tx.activity.findUnique({
+        where: { id: activityId },
+        include: { cart: true },
+      });
+
+      if (!targetActivity) {
+        throw new Error("ACTIVITY_NOT_FOUND");
+      }
+      if (targetActivity.cart.userId !== userId) {
+        throw new Error("NOT_CART_OWNER");
+      }
+
+      const { prevId, nextId, dayOfWeek, ...rest } = updatedData;
+      const dataToUpdate: Omit<
+        UpdateActivityBodySchema,
+        "prevId" | "nextId" | "dayOfWeek"
+      > & {
+        dayOfWeek?: ReturnType<typeof mapDayOfWeek>;
+        cartOrder?: string;
+      } = { ...rest };
+
+      if (dayOfWeek !== undefined) {
+        dataToUpdate.dayOfWeek = mapDayOfWeek(dayOfWeek);
+      }
+
+      if (prevId !== undefined || nextId !== undefined) {
+        const [prevActivity, nextActivity] = await Promise.all([
+          prevId ? tx.activity.findUnique({ where: { id: prevId } }) : null,
+          nextId ? tx.activity.findUnique({ where: { id: nextId } }) : null,
+        ]);
+        dataToUpdate.cartOrder = LexoRankService.getBetweenRank(
+          prevActivity?.cartOrder,
+          nextActivity?.cartOrder,
+        );
+      }
+
+      return tx.activity.update({
+        where: { id: activityId },
+        data: dataToUpdate,
+      });
+    });
+  },
+
+  deleteActivity: async (userId: string, activityId: string) => {
+    await prisma.$transaction(async (tx) => {
+      const targetActivity = await tx.activity.findUnique({
+        where: { id: activityId },
+        include: { cart: true },
+      });
+
+      if (!targetActivity) {
+        throw new Error("ACTIVITY_NOT_FOUND");
+      }
+      if (targetActivity.cart.userId !== userId) {
+        throw new Error("NOT_CART_OWNER");
+      }
+
+      await tx.activity.delete({ where: { id: activityId } });
+    });
+  },
+};

--- a/apps/core/src/services/announcementService.ts
+++ b/apps/core/src/services/announcementService.ts
@@ -1,0 +1,22 @@
+import { prisma } from "../db/clients.js";
+
+export const announcementService = {
+  listAnnouncements: async () => {
+    return prisma.announcement.findMany({
+      select: { id: true, title: true, createdAt: true, updatedAt: true },
+      orderBy: { createdAt: "desc" },
+    });
+  },
+
+  getAnnouncementById: async (announcementId: string) => {
+    const announcement = await prisma.announcement.findUnique({
+      where: { id: announcementId },
+    });
+
+    if (!announcement) {
+      throw new Error("ANNOUNCEMENT_NOT_FOUND");
+    }
+
+    return announcement;
+  },
+};

--- a/apps/core/src/services/cartsService.ts
+++ b/apps/core/src/services/cartsService.ts
@@ -155,6 +155,7 @@ export const cartService = {
             },
           },
         },
+        activities: { orderBy: { cartOrder: "asc" } },
       },
     });
 
@@ -212,6 +213,20 @@ export const cartService = {
           }
         : null,
       sections: item.sections,
+    }));
+
+    // 2b. Format Activity Items Response
+    const activityItemsResponse = R.map(cart.activities, (act) => ({
+      id: act.id,
+      cartId: act.cartId,
+      title: act.title,
+      description: act.description,
+      dayOfWeek: act.dayOfWeek,
+      periodStart: act.periodStart,
+      periodEnd: act.periodEnd,
+      color: act.color,
+      hidden: act.hidden,
+      cartOrder: act.cartOrder,
     }));
 
     // 3. Extract Schedules
@@ -288,6 +303,7 @@ export const cartService = {
         cartOrder: cart.cartOrder,
         visible: cart.visible,
         items: itemsResponse,
+        activityItems: activityItemsResponse,
       },
       summary: {
         totalCredits: R.sumBy(enrichedItems, (x: any) =>

--- a/packages/zod-schemas/activity.response.schema.ts
+++ b/packages/zod-schemas/activity.response.schema.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+
+import { days } from "./constants.js";
+
+export const ActivityItemSchema = z.object({
+  id: z.string(),
+  cartId: z.string(),
+  title: z.string(),
+  description: z.string(),
+  dayOfWeek: days,
+  periodStart: z.string(),
+  periodEnd: z.string(),
+  color: z.string().nullable(),
+  hidden: z.boolean(),
+  cartOrder: z.string(),
+});
+
+export const SingleActivityResponseSchema = z.object({
+  data: ActivityItemSchema,
+});
+
+export type ActivityItem = z.infer<typeof ActivityItemSchema>;

--- a/packages/zod-schemas/activity.schema.ts
+++ b/packages/zod-schemas/activity.schema.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+import { days, TIME_REGEX } from "./constants.js";
+
+export const CreateActivityBodySchema = z
+  .object({
+    cartId: z.string(),
+    title: z.string().nonempty(),
+    description: z.string(),
+    dayOfWeek: days,
+    periodStart: z.string().regex(TIME_REGEX),
+    periodEnd: z.string().regex(TIME_REGEX),
+    color: z.string().optional(),
+    hidden: z.boolean().optional(),
+  })
+  .strict();
+
+export type CreateActivityBodySchema = z.output<
+  typeof CreateActivityBodySchema
+>;
+
+export const UpdateActivityBodySchema = z
+  .object({
+    title: z.string().nonempty().optional(),
+    description: z.string().optional(),
+    dayOfWeek: days.optional(),
+    periodStart: z.string().regex(TIME_REGEX).optional(),
+    periodEnd: z.string().regex(TIME_REGEX).optional(),
+    color: z.string().optional(),
+    hidden: z.boolean().optional(),
+    prevId: z.string().optional(),
+    nextId: z.string().optional(),
+  })
+  .strict();
+
+export type UpdateActivityBodySchema = z.output<
+  typeof UpdateActivityBodySchema
+>;
+
+export const ActivityIdParamSchema = z.object({
+  activityId: z.string(),
+});
+
+export type ActivityIdParamSchema = z.infer<typeof ActivityIdParamSchema>;

--- a/packages/zod-schemas/announcement.response.schema.ts
+++ b/packages/zod-schemas/announcement.response.schema.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+export const AnnouncementListItemSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  createdAt: z.date().or(z.string()),
+  updatedAt: z.date().or(z.string()),
+});
+
+export const AnnouncementDetailSchema = AnnouncementListItemSchema.extend({
+  content: z.string(),
+});
+
+export const ListAnnouncementsResponseSchema = z.object({
+  data: z.array(AnnouncementListItemSchema),
+});
+
+export const AnnouncementDetailResponseSchema = z.object({
+  data: AnnouncementDetailSchema,
+});
+
+export type AnnouncementListItem = z.infer<typeof AnnouncementListItemSchema>;
+export type AnnouncementDetail = z.infer<typeof AnnouncementDetailSchema>;

--- a/packages/zod-schemas/announcement.schema.ts
+++ b/packages/zod-schemas/announcement.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const AnnouncementIdParamSchema = z.object({
+  announcementId: z.string(),
+});
+
+export type AnnouncementIdParamSchema = z.infer<
+  typeof AnnouncementIdParamSchema
+>;

--- a/packages/zod-schemas/carts.response.schema.ts
+++ b/packages/zod-schemas/carts.response.schema.ts
@@ -1,5 +1,6 @@
 import z from "zod";
 
+import { ActivityItemSchema } from "./activity.response.schema.js";
 import { genEdType, semester, studyProgram, visible } from "./constants.js";
 import { Section } from "./types.js";
 
@@ -69,6 +70,7 @@ export const CartData = CartWithItemsBaseSchema.extend({
   isDefault: z.boolean(),
   cartOrder: z.string(),
   items: z.array(CartItemDetailSchema),
+  activityItems: z.array(ActivityItemSchema),
 });
 
 export const ClassScheduleItemSchema = z.object({

--- a/packages/zod-schemas/index.ts
+++ b/packages/zod-schemas/index.ts
@@ -1,4 +1,6 @@
 export * from "./admin.schema.js";
+export * from "./announcement.response.schema.js";
+export * from "./announcement.schema.js";
 export * from "./carts.response.schema.js";
 export * from "./carts.schema.js";
 export * from "./constants.js";

--- a/packages/zod-schemas/index.ts
+++ b/packages/zod-schemas/index.ts
@@ -1,3 +1,5 @@
+export * from "./activity.response.schema.js";
+export * from "./activity.schema.js";
 export * from "./admin.schema.js";
 export * from "./announcement.response.schema.js";
 export * from "./announcement.schema.js";

--- a/packages/zod-schemas/package.json
+++ b/packages/zod-schemas/package.json
@@ -23,6 +23,8 @@
   "exports": {
     ".": "./index.ts",
     "./constants": "./constants.ts",
+    "./activity": "./activity.schema.ts",
+    "./activity-response": "./activity.response.schema.ts",
     "./admin": "./admin.schema.ts",
     "./announcement": "./announcement.schema.ts",
     "./announcement-response": "./announcement.response.schema.ts",

--- a/packages/zod-schemas/package.json
+++ b/packages/zod-schemas/package.json
@@ -24,6 +24,8 @@
     ".": "./index.ts",
     "./constants": "./constants.ts",
     "./admin": "./admin.schema.ts",
+    "./announcement": "./announcement.schema.ts",
+    "./announcement-response": "./announcement.response.schema.ts",
     "./carts": "./carts.schema.ts",
     "./carts-response": "./carts.response.schema.ts",
     "./courses": "./courses.schema.ts",


### PR DESCRIPTION
## Summary
- Adds public `GET /api/v1/announcement` (list) and `GET /api/v1/announcement/:announcementId` (detail) endpoints.
- Adds `POST/PATCH/DELETE /api/v1/activity` for custom timetable blocks, each cart-scoped with its own independent LexoRank ordering (separate from `CartItem`'s).
- `GET /api/v1/carts/:cartId` now returns `activityItems` alongside `items`.
- Follows the existing routes_define / routes / service pattern used by `carts`.

## Test plan
- [x] `npx tsc --noEmit` — no new type errors introduced
- [x] Manually verified via `curl` against `pnpm dev`: announcement list/detail/404, activity create/update/reorder/delete/404, cart detail embedding activityItems
- [x] Confirmed routes documented at `/api/v1/docs`
- [ ] `403 NOT_CART_OWNER` path for activity not exercised (non-prod auth bypass hardcodes a single dev user, no second user available to test cross-ownership)