### PR TITLE
feat: make text aligned to the left if course block is less than an hour

### DIFF
--- a/packages/ui/src/lib/components/atoms/timetable/timetable-course-card.svelte
+++ b/packages/ui/src/lib/components/atoms/timetable/timetable-course-card.svelte
@@ -50,10 +50,10 @@
 	{...rest}
 >
 	<!-- NOTE: Scaling on some resolution is kinda wonky -->
-	{#if length === 1}
-		<!-- <span class="truncate text-[13cqh]">{course.code}</span> -->
-		<span class="truncate text-[15cqh] font-medium">{course.abbrName}</span>
-		<span class="truncate text-[13cqh]">
+	{#if length <= 1}
+		<span class="truncate text-[13cqh]">{course.code}</span>
+		<span class="w-full truncate text-left text-[15cqh] font-medium">{course.abbrName}</span>
+		<span class="w-full truncate text-center text-[13cqh]">
 			{course.bldg}
 			{course.room}
 		</span>


### PR DESCRIPTION
## Why did you create this PR

- Fix UI for courseblock

## What did you do

- Make course name text align to the left if the course block is too short ( <= 1 hour)

## Demo

<img width="1142" height="493" alt="image" src="https://github.com/user-attachments/assets/ccaa8491-815d-4b9d-860d-3e5fc933af43" />
