### PR TITLE
fix(core): include prisma.config.ts in the production image

### DIFF
--- a/apps/core/Dockerfile
+++ b/apps/core/Dockerfile
@@ -43,6 +43,7 @@ COPY --from=build /tmp/deploy/node_modules ./node_modules
 COPY --from=build /tmp/deploy/dist ./dist
 COPY --from=build /tmp/deploy/package.json ./package.json
 COPY --from=build /tmp/deploy/prisma ./prisma
+COPY --from=build /tmp/deploy/prisma.config.ts ./prisma.config.ts
 
 EXPOSE 3000
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Summary
- The final Docker stage for `apps/core` explicitly copies only `node_modules`, `dist`, `package.json`, and `prisma/` from the `pnpm deploy --prod` output — `prisma.config.ts` was never one of them, even though `pnpm deploy` already produces it in that output.
- Prisma 7 loads `prisma.config.ts` before anything else, including `prisma migrate deploy`. Without it in the final image, any tooling that runs Prisma CLI commands against the deployed image (e.g. a migration Job) can't find its config.

## Test plan
- [x] Verified by running `pnpm --filter ./apps/core deploy --prod --legacy <dir>` and confirming `prisma.config.ts` is present in that output
- [x] Copied `prisma.config.ts` into that trimmed (`--prod`-only, no devDependencies) fileset and ran `prisma migrate deploy` against a real database — loaded config and connected successfully