### PR TITLE
Fix: Exam schedule UI fix

### DIFF
--- a/apps/cugetreg/src/lib/components/exams-list.svelte
+++ b/apps/cugetreg/src/lib/components/exams-list.svelte
@@ -140,7 +140,7 @@
                   code: exam.courseNo,
                   bldg: '',
                   room: '',
-                  section: 0,
+                  section: exam.sectionNo,
                 }}
                 col={formatExamColumn(exam.start ?? undefined) -
                   TIMETABLE_DEFAULT_START}
@@ -180,7 +180,7 @@
                   code: examCourse.courseNo,
                   bldg: '',
                   room: '',
-                  section: 0,
+                  section: examCourse.sectionNo,
                 }}
                 col={formatExamColumn(examCourse.start ?? undefined) -
                   TIMETABLE_DEFAULT_START}

--- a/apps/cugetreg/src/lib/components/exams-list.svelte
+++ b/apps/cugetreg/src/lib/components/exams-list.svelte
@@ -58,6 +58,25 @@
   const finalEndTime = $derived(
     getLatestExamTime(finalExams, TIMETABLE_DEFAULT_END),
   );
+
+  function formatTableDate(date: Date) {
+    const months = [
+      'ม.ค.',
+      'ก.พ.',
+      'มี.ค.',
+      'เม.ย.',
+      'พ.ค.',
+      'มิ.ย.',
+      'ก.ค.',
+      'ส.ค.',
+      'ก.ย.',
+      'ต.ค.',
+      'พ.ย.',
+      'ธ.ค.',
+    ];
+
+    return `${date.getDate()} ${months[date.getMonth()]} ${String(date.getFullYear() + 543).slice(-2)}`;
+  }
 </script>
 
 <div class="flex flex-row items-center justify-between lg:justify-center">
@@ -128,7 +147,7 @@
         periodPerDay={midtermEndTime - TIMETABLE_DEFAULT_START}
         days={examDateOrder.midterms
           .filter((time) => time !== 0)
-          .map((time) => formatDate(new Date(time)))}
+          .map((time) => formatTableDate(new Date(time)))}
       >
         {#each examDateOrder.midterms.filter((time) => time !== 0) as key, index (key)}
           {#each examsData.midterms[key] as exam (exam.cartItemId)}
@@ -168,7 +187,7 @@
         periodPerDay={finalEndTime - TIMETABLE_DEFAULT_START}
         days={examDateOrder.finals
           .filter((time) => time !== 0)
-          .map((time) => formatDate(new Date(time)))}
+          .map((time) => formatTableDate(new Date(time)))}
       >
         {#each examDateOrder.finals.filter((time) => time !== 0) as key, index (key)}
           {#each examsData.finals[key] as examCourse (examCourse.cartItemId)}

--- a/apps/cugetreg/src/lib/utils/schedule.ts
+++ b/apps/cugetreg/src/lib/utils/schedule.ts
@@ -22,6 +22,7 @@ export type ExamData = {
   start: Date | null;
   end: Date | null;
   duration: number; // calculated here
+  sectionNo: number;
 };
 
 export function parsePeriodTime(periodTime: string): number {
@@ -181,6 +182,7 @@ export function getExamData(
       const data: ExamData = {
         cartItemId: exam.cartItemId,
         courseNo: exam.courseNo,
+        sectionNo: course.sectionNo,
         name:
           course.course.courseNameEn ||
           course.course.courseNameTh ||

--- a/apps/cugetreg/src/routes/Home.svelte
+++ b/apps/cugetreg/src/routes/Home.svelte
@@ -605,7 +605,7 @@
   );
 </script>
 
-<div class="relative flex h-screen flex-col overflow-hidden bg-white">
+<div class="relative flex h-full flex-col overflow-hidden bg-white">
   <div class="relative flex flex-1 overflow-hidden">
     <AppSidebar
       showSidebar={!isMobile}


### PR DESCRIPTION
## Why did you create this PR 

- Fix minor UI bug in exam schedule and home page.
- Fixes #1014 

## What did you do

- Create a local function formatTableDate in exam-list component to display only date, month and last 2 digits of year.
- Add SectionNo prop to schedule.ts to pass the correct section into exam schedule.
- Fix Home page height class to make the page the exceed the height of the screen.

## Demo
<img width="1255" height="478" alt="image" src="https://github.com/user-attachments/assets/e7c6ce90-0a99-4e18-a8cc-fee9e51bda17" />
<img width="644" height="995" alt="image" src="https://github.com/user-attachments/assets/3905997b-72ab-4be5-99af-1b894eb589ef" />


