### PR TITLE
Feat: add credit filter to backend

### DIFF
--- a/apps/core/prisma/sql/getCourseList.sql
+++ b/apps/core/prisma/sql/getCourseList.sql
@@ -17,6 +17,8 @@
 -- @param {String} $14:sortBy? Sort column ('NAME', 'CAPACITY_SUM', 'REMAINING_SUM'; default 'REMAINING_SUM')
 -- @param {String} $15:sortOrder? Sort direction ('ASC', 'DESC'; default 'ASC')
 -- @param {String} $16:fitCartId? Optional cart ID — when set, excludes sections whose classes overlap with the cart's sections
+-- @param {Decimal} $17:creditMin? Optional minimum credit
+-- @param {Decimal} $18:creditMax? Optional maximum credit
 
 -- Step 0: Precompute cart's occupied class slots once (avoids a correlated
 --         subquery in matching_sections when $16 is provided).
@@ -75,6 +77,10 @@ matching_sections AS (
 
         -- Grading type (optional)
         AND ($7::grading_type IS NULL OR ci.grading_type = $7::grading_type)
+
+        -- Credit range (optional)
+        AND ($17::numeric IS NULL OR ci.credit >= $17::numeric)
+        AND ($18::numeric IS NULL OR ci.credit <= $18::numeric)
 
         -- No prereq (optional boolean)
         AND ($9::boolean IS NOT TRUE

--- a/apps/core/src/services/coursesService.ts
+++ b/apps/core/src/services/coursesService.ts
@@ -25,6 +25,8 @@ export async function queryCourse(
     timeEnd,
     noPrereq,
     fitCartId,
+    creditMin,
+    creditMax,
   } = query;
 
   const selectedGenEdTypes =
@@ -71,6 +73,8 @@ export async function queryCourse(
       sortBy ?? null,
       sortOrder ?? "desc",
       fitCartId ?? null,
+      creditMin ?? null,
+      creditMax ?? null,
     ),
   );
 

--- a/packages/zod-schemas/courses.schema.ts
+++ b/packages/zod-schemas/courses.schema.ts
@@ -22,6 +22,8 @@ export const GetCourseQuerySchema = z.object({
   days: z.union([z.array(days), days]).optional(),
   timeStart: z.string().regex(TIME_REGEX).optional(),
   timeEnd: z.string().regex(TIME_REGEX).optional(),
+  creditMin: z.coerce.number().optional(),
+  creditMax: z.coerce.number().optional(),
   noPrereq: z.coerce.boolean().optional(),
   fitCartId: z.string().optional(),
   assessment: assessment.optional(),


### PR DESCRIPTION
## Why did you create this PR

- Add credit filter to backend
- Feat #1025

## What did you do

- Add creditMin, creditMax in to course schema and filter in sql
