### PR TITLE
fix(web): externalize jsdom to fix course-page 500 error

### DIFF
--- a/apps/cugetreg/package.json
+++ b/apps/cugetreg/package.json
@@ -72,6 +72,7 @@
     "clsx": "^2.1.1",
     "html2canvas": "^1.4.1",
     "html2canvas-pro": "^1.6.4",
+    "jsdom": "^29.1.1",
     "lucide-svelte": "^0.560.0",
     "svelte-french-toast": "^1.2.0",
     "svelte-markdown": "^0.4.1",

--- a/apps/cugetreg/vite.config.ts
+++ b/apps/cugetreg/vite.config.ts
@@ -5,4 +5,12 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   plugins: [sveltekit(), tailwindcss()],
   assetsInclude: ['**/*.md'],
+  // isomorphic-dompurify pulls in jsdom (for server-side sanitization), whose
+  // css-tree dependency does `require('../data/patch.json')` relative to its
+  // own file location. Bundling jsdom into the SSR chunk breaks that relative
+  // path, so keep it external and let Node resolve it from node_modules
+  // (present at runtime — see apps/cugetreg/Dockerfile's pruned prod deploy).
+  ssr: {
+    external: ['jsdom'],
+  },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       html2canvas-pro:
         specifier: ^1.6.4
         version: 1.6.4
+      jsdom:
+        specifier: ^29.1.1
+        version: 29.1.1(@noble/hashes@2.0.1)
       lucide-svelte:
         specifier: ^0.560.0
         version: 0.560.0(svelte@5.46.4)


### PR DESCRIPTION
## Problem

Any route that renders `SectionTable` (e.g. `/course-page/[courseId]`) 500s
in production with:

```
Error: Cannot find module '../data/patch.json'
    at .../build/server/chunks/section-table-*.js
```

`packages/ui`'s `comment.svelte` uses `isomorphic-dompurify` for
server-side sanitization, which pulls in `jsdom`. `jsdom`'s own
dependency, `css-tree`, does `require('../data/patch.json')` relative
to its own file location. Vite bundles this into a single SSR chunk,
which breaks that relative path at runtime — the JSON file isn't where
`css-tree` expects it once bundled.

## Fix

1. Mark `jsdom` external in the SSR build (`ssr.external`) so Vite
   leaves it as a plain runtime `import`/`require` instead of bundling
   it — `css-tree`'s relative path resolves correctly against its real
   `node_modules` location.
2. Declare `jsdom` as a **direct** dependency of `apps/cugetreg`.
   pnpm's strict `node_modules` only symlinks direct dependencies to a
   package's own `node_modules`; `jsdom` was previously only reachable
   transitively (via `isomorphic-dompurify`), so the external import
   couldn't resolve at runtime (`ERR_MODULE_NOT_FOUND`) until this was
   added.

## Verification

- Reproduced the exact `pnpm --filter ./apps/cugetreg deploy --prod --legacy`
  step from `apps/cugetreg/Dockerfile` locally and confirmed `jsdom` is
  now symlinked at the top level of the pruned production
  `node_modules`.
- Rebuilt and confirmed the `section-table` SSR chunk no longer
  contains `css-tree`/`patch.json` — `jsdom` is now a clean external
  `import`.
- Deployed to our beta environment and confirmed
  `/course-page/[courseId]` (previously 500ing) now returns 200 with
  no errors in server logs.