### PR TITLE
fix(core): chown final-stage Docker files to node user

### DIFF
--- a/apps/core/Dockerfile
+++ b/apps/core/Dockerfile
@@ -39,11 +39,16 @@ RUN pnpm --filter ./apps/core deploy --prod --legacy /tmp/deploy
 FROM base AS final
 ENV NODE_ENV=production
 USER node
-COPY --from=build /tmp/deploy/node_modules ./node_modules
-COPY --from=build /tmp/deploy/dist ./dist
-COPY --from=build /tmp/deploy/package.json ./package.json
-COPY --from=build /tmp/deploy/prisma ./prisma
-COPY --from=build /tmp/deploy/prisma.config.ts ./prisma.config.ts
+# --chown=node:node: without it these land root-owned (COPY preserves the
+# build stage's ownership, which never switches off root) while the process
+# runs as `node` — fine for read-only serving, but `prisma migrate deploy`
+# writes into node_modules/.pnpm/@prisma+engines*/node_modules/@prisma/engines
+# at runtime and gets a permission error without this.
+COPY --from=build --chown=node:node /tmp/deploy/node_modules ./node_modules
+COPY --from=build --chown=node:node /tmp/deploy/dist ./dist
+COPY --from=build --chown=node:node /tmp/deploy/package.json ./package.json
+COPY --from=build --chown=node:node /tmp/deploy/prisma ./prisma
+COPY --from=build --chown=node:node /tmp/deploy/prisma.config.ts ./prisma.config.ts
 
 EXPOSE 3000
 CMD ["node", "dist/index.js"]


### PR DESCRIPTION
## Problem

`apps/core/Dockerfile`'s final stage runs as `USER node`, but the
`COPY --from=build` lines never set ownership — `COPY` preserves the
build stage's ownership, which is root, since the build stage never
switches off root. The files land root-owned in the final image even
though the process runs as `node`.

This is invisible for normal read-only serving, but `prisma migrate
deploy` writes into `node_modules/.pnpm/@prisma+engines*/node_modules/@prisma/engines`
at runtime to verify/fetch its query engine, and fails with a
permission error when that directory is root-owned:

```
Can't write to node_modules/.pnpm/@prisma+engines*/.../@prisma/engines
... make sure you install prisma with the right permissions
```

We hit this running `prisma migrate deploy` against this image outside
the normal `node dist/index.js` entrypoint (e.g. a one-off migration
step in CI/CD).

## Fix

Add `--chown=node:node` to the final stage's `COPY --from=build` lines
so the copied files actually belong to the user the container runs as.

## Verification

Confirmed the migration step that previously failed with the
permission error now runs successfully against an image built with
this change.