### PR TITLE
feat(core): add internal-token-gated announcement creation endpoint

### DIFF
--- a/apps/core/.env.example
+++ b/apps/core/.env.example
@@ -12,3 +12,4 @@ APP_MODE=dev
 BETTER_AUTH_SECRET=ABCdsfsvsdkjvdakj
 BETTER_AUTH_URL=http://localhost:3000
 FIX_PERIOD_SWAPS=true
+INTERNAL_API_TOKEN=change-me-to-a-random-32-char-value

--- a/apps/core/src/env.ts
+++ b/apps/core/src/env.ts
@@ -13,6 +13,7 @@ export const env = createEnv({
     BETTER_AUTH_SECRET: z.string().min(1),
     BETTER_AUTH_URL: z.string().min(1),
     BETTER_AUTH_TRUSTED_ORIGINS: z.string().optional(),
+    INTERNAL_API_TOKEN: z.string().min(16),
   },
   runtimeEnv: process.env,
 });

--- a/apps/core/src/index.ts
+++ b/apps/core/src/index.ts
@@ -2,9 +2,14 @@ import type { Variables } from "@/lib/auth.js";
 import activity from "@/routes/activity.js";
 import admin from "@/routes/admin.js";
 import announcement from "@/routes/announcement.js";
-import authRoute, { includeAuth, middlewareAuth } from "@/routes/auth.js";
+import authRoute, {
+  includeAuth,
+  middlewareAuth,
+  middlewareInternalToken,
+} from "@/routes/auth.js";
 import carts from "@/routes/carts.js";
 import courses from "@/routes/courses.js";
+import internalAnnouncement from "@/routes/internalAnnouncement.js";
 import publicCarts from "@/routes/publicCarts.js";
 import reviews from "@/routes/reviews.js";
 import user from "@/routes/user.js";
@@ -51,10 +56,20 @@ app.openAPIRegistry.registerComponent("securitySchemes", "CookieAuth", {
   name: "better-auth.session_token",
 });
 
+// Shared-secret scheme for service-to-service routes (e.g. CI creating an announcement)
+app.openAPIRegistry.registerComponent("securitySchemes", "InternalToken", {
+  type: "apiKey",
+  in: "header",
+  name: "X-Internal-Token",
+});
+
 // Public routes — no auth required
 app.route("/public/carts", publicCarts);
 app.route("/auth", authRoute);
 app.route("/announcement", announcement);
+
+app.use("/internal/*", middlewareInternalToken);
+app.route("/internal/announcement", internalAnnouncement);
 
 app.use("/courses/*", includeAuth);
 

--- a/apps/core/src/routes/auth.ts
+++ b/apps/core/src/routes/auth.ts
@@ -34,6 +34,18 @@ export const middlewareAuth: MiddlewareHandler = async (c, next) => {
   await next();
 };
 
+// Guards service-to-service routes (e.g. CI creating an announcement) with a
+// shared-secret header instead of a user session — there's no session to check.
+export const middlewareInternalToken: MiddlewareHandler = async (c, next) => {
+  const token = c.req.header("X-Internal-Token");
+
+  if (!token || token !== env.INTERNAL_API_TOKEN) {
+    return c.json({ message: "Unauthorized" }, 401);
+  }
+
+  await next();
+};
+
 export const includeAuth: MiddlewareHandler = async (c, next) => {
   if (env.APP_MODE !== "prod") {
     c.set("user", {

--- a/apps/core/src/routes/internalAnnouncement.ts
+++ b/apps/core/src/routes/internalAnnouncement.ts
@@ -1,0 +1,21 @@
+import { createAnnouncementRoute } from "@/routes_define/announcement.routes.js";
+import { announcementService } from "@/services/announcementService.js";
+
+import { OpenAPIHono } from "@hono/zod-openapi";
+
+const internalAnnouncement = new OpenAPIHono();
+
+internalAnnouncement.openapi(createAnnouncementRoute, async (c) => {
+  try {
+    const { title, content } = c.req.valid("json");
+    const created = await announcementService.createAnnouncement({
+      title,
+      content,
+    });
+    return c.json({ data: created }, 201);
+  } catch {
+    return c.json({ error: "INTERNAL_SERVER_ERROR" }, 500);
+  }
+});
+
+export default internalAnnouncement;

--- a/apps/core/src/routes_define/announcement.routes.ts
+++ b/apps/core/src/routes_define/announcement.routes.ts
@@ -1,6 +1,9 @@
 import { createRoute } from "@hono/zod-openapi";
 
-import { AnnouncementIdParamSchema } from "@cugetreg/zod-schemas/announcement";
+import {
+  AnnouncementIdParamSchema,
+  CreateAnnouncementBodySchema,
+} from "@cugetreg/zod-schemas/announcement";
 import {
   AnnouncementDetailResponseSchema,
   ListAnnouncementsResponseSchema,
@@ -38,4 +41,26 @@ export const getAnnouncementByIdRoute = createRoute({
     404: errorRes("ANNOUNCEMENT_NOT_FOUND"),
     500: InternalError,
   },
+});
+
+export const createAnnouncementRoute = createRoute({
+  method: "post",
+  path: "/",
+  summary: "Create announcement (internal/service use only)",
+  request: {
+    body: {
+      content: { "application/json": { schema: CreateAnnouncementBodySchema } },
+    },
+  },
+  responses: {
+    201: {
+      content: {
+        "application/json": { schema: AnnouncementDetailResponseSchema },
+      },
+      description: "Created",
+    },
+    401: errorRes("UNAUTHORIZED"),
+    500: InternalError,
+  },
+  security: [{ InternalToken: [] }],
 });

--- a/apps/core/src/services/announcementService.ts
+++ b/apps/core/src/services/announcementService.ts
@@ -19,4 +19,14 @@ export const announcementService = {
 
     return announcement;
   },
+
+  createAnnouncement: async ({
+    title,
+    content,
+  }: {
+    title: string;
+    content: string;
+  }) => {
+    return prisma.announcement.create({ data: { title, content } });
+  },
 };

--- a/packages/zod-schemas/announcement.schema.ts
+++ b/packages/zod-schemas/announcement.schema.ts
@@ -7,3 +7,12 @@ export const AnnouncementIdParamSchema = z.object({
 export type AnnouncementIdParamSchema = z.infer<
   typeof AnnouncementIdParamSchema
 >;
+
+export const CreateAnnouncementBodySchema = z.object({
+  title: z.string().min(1),
+  content: z.string().min(1),
+});
+
+export type CreateAnnouncementBodySchema = z.infer<
+  typeof CreateAnnouncementBodySchema
+>;


### PR DESCRIPTION
## Motivation

`apps/core` currently has read-only announcement routes
(`GET /announcement`, `GET /announcement/:id`) but no way to create
one through the API — presumably announcements are created directly
against the DB or through tooling outside this repo today.

We wanted a CI job to automatically post a release announcement when a
prod release's gitops PR merges (pulling the changelog from GitHub
Release notes), which needs a create endpoint that isn't gated behind
normal user session auth, since it's a service-to-service call.

## What this adds

- `POST /internal/announcement` — creates an announcement, guarded by
  a shared-secret `X-Internal-Token` header
  (`middlewareInternalToken` in `routes/auth.ts`) instead of the usual
  session auth.
- `INTERNAL_API_TOKEN` env var (documented in `.env.example`, validated
  in `env.ts`).
- `createAnnouncement` in `announcementService.ts` and
  `CreateAnnouncementBodySchema` in `packages/zod-schemas` — both pure
  additions, nothing existing was changed.

The existing public `GET /announcement` routes are untouched and stay
public/unauthenticated.

## Compatibility with existing announcement work

Checked this against the announcement feature already on `mvp1-dev`
(#1000, #1021) — there's no overlap: that work is read/list-focused,
this only adds a creation path. `announcementService.ts` and
`announcement.schema.ts` diffs are purely additive (nothing existing
was modified), so this should apply cleanly regardless of how that
feature evolves.

## Verification

Deployed this on our fork and exercised it directly against our beta
environment:

```
curl -X POST https://<beta>/api/v1/internal/announcement \
  -H "X-Internal-Token: ..." \
  -H "Content-Type: application/json" \
  -d '{"title":"...","content":"..."}'
```

→ `201`, announcement created correctly, visible via the existing
`GET /announcement` route.

Happy to adjust naming/shape if you'd rather this live elsewhere or
follow a different auth pattern.