### PR TITLE
Align sidebar UI across pages & fix mobile/layout issues

### DIFF
--- a/apps/cugetreg/src/lib/components/app-sidebar.svelte
+++ b/apps/cugetreg/src/lib/components/app-sidebar.svelte
@@ -84,7 +84,7 @@
             class="bg-surface flex flex-1 flex-col overflow-hidden border border-neutral-100 group-data-[state=collapsed]:absolute group-data-[state=collapsed]:top-4 group-data-[state=collapsed]:left-[calc(var(--sidebar-width-icon)+1rem)] group-data-[state=collapsed]:z-50 group-data-[state=collapsed]:max-h-[min(800px,calc(100%-2rem))] group-data-[state=collapsed]:w-[400px] group-data-[state=collapsed]:rounded-3xl group-data-[state=collapsed]:shadow-2xl md:px-2 md:pt-0 md:pb-8"
           >
             <div
-              class="flex-1 overflow-y-auto pr-6 pb-10 [-ms-overflow-style:none] [scrollbar-width:none] md:pr-8 [&::-webkit-scrollbar]:hidden"
+              class="flex-1 overflow-y-auto pb-10 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
               style="overscroll-behavior: contain"
             >
               {@render panelContent({ openPanel, expanded })}

--- a/apps/cugetreg/src/lib/components/selected-course.svelte
+++ b/apps/cugetreg/src/lib/components/selected-course.svelte
@@ -3,7 +3,6 @@
   import { getUserCartStore, useCartActions } from '$lib/stores/user-cart';
 
   import {
-    BookMarked,
     ChevronDown,
     Equal,
     Eye,
@@ -18,7 +17,6 @@
   import { cubicOut } from 'svelte/easing';
   import { slide } from 'svelte/transition';
 
-  import * as Accordion from '@cugetreg/ui/atoms/accordion';
   import { Button } from '@cugetreg/ui/atoms/button';
   import { GenedChip } from '@cugetreg/ui/atoms/gened-chip';
   import { IconButton } from '@cugetreg/ui/atoms/icon-button';
@@ -66,6 +64,8 @@
     open?: boolean;
     /** Show a divider between the header and the body while expanded. */
     headerDivider?: boolean;
+    /** When false, the section can't collapse (no chevron) and stays open. */
+    collapsible?: boolean;
   }
 
   let {
@@ -74,6 +74,7 @@
     onArrange,
     open = $bindable(true),
     headerDivider = false,
+    collapsible = true,
   }: SelectedCourseProp = $props();
 
   const totalCredit = $derived(
@@ -82,6 +83,8 @@
       0,
     ),
   );
+
+  const bodyOpen = $derived(collapsible ? open : true);
 
   let showChangeColorModal = $state(false);
   let currentColorVariant = $state<ColorVariant>('primary');
@@ -107,29 +110,9 @@
 <div class={cn(className)}>
   {#if variant === 'grouped'}
     <div class="flex flex-col">
-      <button
-        type="button"
-        onclick={() => (open = !open)}
-        aria-expanded={open}
-        class="mb-4 flex w-full items-center justify-between"
-      >
-        <span class="flex items-baseline gap-2">
-          <h2 class="text-on-surface text-lg/[20px] font-medium">
-            วิชาที่เลือก
-          </h2>
-          <span class="text-xs font-normal text-neutral-400"
-            >{totalCredit} หน่วยกิต</span
-          >
-        </span>
-        <ChevronDown
-          size={20}
-          class="text-gray-400 transition-transform duration-200 {open
-            ? 'rotate-180'
-            : ''}"
-        />
-      </button>
+      {@render sectionHeader()}
 
-      {#if open}
+      {#if bodyOpen}
         <div transition:slide={{ duration: 250, easing: cubicOut }}>
           {#if headerDivider}
             <hr class="mb-4 border-t border-neutral-100" />
@@ -157,19 +140,14 @@
       {/if}
     </div>
   {:else}
-    <Accordion.Root class="w-full" type="single" value="selected-course">
-      <Accordion.Item value="selected-course">
-        <Accordion.Trigger class="border-b border-neutral-200">
-          <div class="flex">
-            <BookMarked class="mr-2" />
-            <span class="">วิชาที่เลือก</span>
-            <span
-              class="ml-2 flex items-baseline-last text-xs font-light text-neutral-400"
-              >{totalCredit} หน่วยกิต</span
-            >
-          </div>
-        </Accordion.Trigger>
-        <Accordion.Content>
+    <div class="flex flex-col">
+      {@render sectionHeader()}
+
+      {#if bodyOpen}
+        <div transition:slide={{ duration: 250, easing: cubicOut }}>
+          {#if headerDivider}
+            <hr class="mb-4 border-t border-neutral-100" />
+          {/if}
           <SortableList.Root
             ondragend={handleDragEnd}
             hasLockedAxis
@@ -178,7 +156,7 @@
               easing: 'cubic-bezier(0.2, 1, 0.1, 1)',
             }}
             gap={0}
-            class="max-h-[40vh] grow overflow-y-scroll"
+            class="max-h-[40vh] grow overflow-y-scroll [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
           >
             {#each schedule as course, index (course.id)}
               <SortableList.Item id={course.id.toString()} {index} class="my-0">
@@ -193,14 +171,47 @@
               >ค้นหาวิชาเรียน</Button
             >
           </div>
-        </Accordion.Content>
-      </Accordion.Item>
-    </Accordion.Root>
+        </div>
+      {/if}
+    </div>
   {/if}
   {#if showChangeColorModal}
     {@render changeColorModal()}
   {/if}
 </div>
+
+{#snippet sectionHeader()}
+  {#if collapsible}
+    <button
+      type="button"
+      onclick={() => (open = !open)}
+      aria-expanded={open}
+      class="mb-4 flex w-full items-center justify-between"
+    >
+      <span class="flex items-baseline gap-2">
+        <h2 class="text-on-surface text-lg/[20px] font-medium">วิชาที่เลือก</h2>
+        <span class="text-xs font-normal text-neutral-400"
+          >{totalCredit} หน่วยกิต</span
+        >
+      </span>
+      <ChevronDown
+        size={20}
+        class="text-gray-400 transition-transform duration-200 {open
+          ? 'rotate-180'
+          : ''}"
+      />
+    </button>
+  {:else}
+    <div class="mb-4 flex w-full items-center justify-between">
+      <span class="flex items-baseline gap-2">
+        <h2 class="text-on-surface text-lg/[20px] font-medium">วิชาที่เลือก</h2>
+        <span class="text-xs font-normal text-neutral-400"
+          >{totalCredit} หน่วยกิต</span
+        >
+      </span>
+    </div>
+  {/if}
+{/snippet}
 
 {#snippet groupedRow(course: CartItemDetail)}
   <div class="flex items-center gap-3 py-3">

--- a/apps/cugetreg/src/routes/Home.svelte
+++ b/apps/cugetreg/src/routes/Home.svelte
@@ -605,7 +605,7 @@
   );
 </script>
 
-<div class="relative flex h-screen flex-col overflow-hidden bg-white">
+<div class="relative flex h-full flex-col overflow-hidden bg-white">
   <div class="relative flex flex-1 overflow-hidden">
     <AppSidebar
       showSidebar={!isMobile}
@@ -1036,10 +1036,10 @@
           <X size={20} strokeWidth={2.5} />
         </button>
         {#if activeModal === 'filter'}
-          {@render FilterContent()}
+          {@render FilterContent(false)}
         {:else if activeModal === 'selected'}
           <div class="flex flex-col gap-6">
-            {@render SelectedContent()}
+            {@render SelectedContent(false)}
             {@render WarningContent()}
           </div>
         {/if}
@@ -1048,22 +1048,28 @@
   {/if}
 </div>
 
-{#snippet FilterContent()}
+{#snippet FilterContent(collapsible = true)}
   <div>
-    <button
-      onclick={() => (isFilterOpen = !isFilterOpen)}
-      aria-expanded={isFilterOpen}
-      class="mb-4 flex w-full items-center justify-between"
-    >
-      <h2 class="text-on-surface text-lg/[20px] font-medium">ตัวกรอง</h2>
-      <ChevronDown
-        size={20}
-        class="text-gray-400 transition-transform duration-200 {isFilterOpen
-          ? 'rotate-180'
-          : ''}"
-      />
-    </button>
-    {#if isFilterOpen}
+    {#if collapsible}
+      <button
+        onclick={() => (isFilterOpen = !isFilterOpen)}
+        aria-expanded={isFilterOpen}
+        class="mb-4 flex w-full items-center justify-between"
+      >
+        <h2 class="text-on-surface text-lg/[20px] font-medium">ตัวกรอง</h2>
+        <ChevronDown
+          size={20}
+          class="text-gray-400 transition-transform duration-200 {isFilterOpen
+            ? 'rotate-180'
+            : ''}"
+        />
+      </button>
+    {:else}
+      <div class="mb-4 flex w-full items-center justify-between">
+        <h2 class="text-on-surface text-lg/[20px] font-medium">ตัวกรอง</h2>
+      </div>
+    {/if}
+    {#if !collapsible || isFilterOpen}
       <div transition:slide={{ duration: 250, easing: cubicOut }}>
         <hr class="mb-4 border-t border-neutral-100" />
         <div class="mb-6">
@@ -1085,18 +1091,19 @@
   </div>
 {/snippet}
 
-{#snippet SelectedContent()}
+{#snippet SelectedContent(collapsible = true)}
   <div>
     {#if $userCart.currentCart}
       <SelectedCourse
         variant="grouped"
         bind:open={isSelectedOpen}
+        {collapsible}
         onArrange={goToSchedule}
         headerDivider
         class="border-b border-neutral-100"
       />
     {:else}
-      <SelectedCourse class="border-b border-neutral-100" />
+      <SelectedCourse {collapsible} class="border-b border-neutral-100" />
     {/if}
   </div>
 {/snippet}

--- a/apps/cugetreg/src/routes/course-page/[courseId]/+page.svelte
+++ b/apps/cugetreg/src/routes/course-page/[courseId]/+page.svelte
@@ -80,11 +80,12 @@
   let selectedTerm = $state(terms[0]);
   let reviewRating = $state(1);
   let reviewContent = $state('');
-  let selectedSection = $state();
+  let selectedSection = $state<HTMLElement>();
 
   let sidebarExpanded = $state(true);
   let openPanel = $state<string | null>(null);
   let activePanel = $state<string | null>(null);
+  let selectedOpen = $state(true);
 
   let timetableSection = $state<HTMLElement>();
   let descriptionSection = $state<HTMLElement>();
@@ -160,6 +161,30 @@
   function scrollToSection(el: HTMLElement | undefined) {
     if (!el) return;
     el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  function focusSelected() {
+    if (sidebarExpanded && selectedOpen) {
+      selectedOpen = false;
+      activePanel = null;
+      return;
+    }
+    sidebarExpanded = true;
+    openPanel = null;
+    selectedOpen = true;
+    activePanel = 'selected_only';
+  }
+
+  function toggleSidebar() {
+    if (sidebarExpanded) {
+      sidebarExpanded = false;
+      activePanel = null;
+    } else {
+      sidebarExpanded = true;
+      activePanel = 'sidebar';
+      openPanel = null;
+      selectedOpen = true;
+    }
   }
 
   const filteredReviews = $derived.by(() =>
@@ -505,75 +530,86 @@
   <div class="relative flex flex-1 overflow-hidden">
     <AppSidebar
       showSidebar={screenWidth >= 1024}
+      panelWidth="490px"
       bind:expanded={sidebarExpanded}
       bind:openPanel
       bind:activePanel
     >
-      {#snippet iconItems({ toggleExpanded, expanded, togglePanel })}
+      {#snippet iconItems({ expanded })}
         <Sidebar.MenuItem>
-          <Sidebar.MenuButton
-            onclick={toggleExpanded}
-            isActive={expanded && activePanel === 'sidebar'}
-            size="lg"
-            tooltipContent="เมนู"
-            class="mx-auto size-12! justify-center rounded-xl p-0! ring-0 transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-6!"
-          >
-            <Menu size="24" strokeWidth={2.5} />
-          </Sidebar.MenuButton>
+          <div class="mt-[0px]">
+            <Sidebar.MenuButton
+              onclick={toggleSidebar}
+              isActive={expanded && activePanel === 'sidebar'}
+              size="lg"
+              tooltipContent="เมนู"
+              class="mx-auto size-12! justify-center rounded-xl p-0! ring-0 transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-5!"
+            >
+              <Menu size="20" strokeWidth={2.5} />
+            </Sidebar.MenuButton>
+          </div>
         </Sidebar.MenuItem>
         <Sidebar.MenuItem>
-          <Sidebar.MenuButton
-            onclick={() => {
-              activePanel = 'description_only';
-              scrollToSection(descriptionSection);
-            }}
-            isActive={activePanel === 'description_only'}
-            size="lg"
-            tooltipContent="คำอธิบายรายวิชา"
-            class="mx-auto size-12! justify-center rounded-xl p-0! transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-6!"
-          >
-            <Book size="24" strokeWidth={2.5} />
-          </Sidebar.MenuButton>
+          <div class="mt-[0px]">
+            <Sidebar.MenuButton
+              onclick={() => {
+                activePanel = 'description_only';
+                scrollToSection(descriptionSection);
+              }}
+              isActive={activePanel === 'description_only'}
+              size="lg"
+              tooltipContent="คำอธิบายรายวิชา"
+              class="mx-auto size-12! justify-center rounded-xl p-0! transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-5!"
+            >
+              <Book size="20" strokeWidth={2.5} />
+            </Sidebar.MenuButton>
+          </div>
         </Sidebar.MenuItem>
         <Sidebar.MenuItem>
-          <Sidebar.MenuButton
-            onclick={() => {
-              activePanel = 'detail_only';
-              scrollToSection(detailSection);
-            }}
-            isActive={activePanel === 'detail_only'}
-            size="lg"
-            tooltipContent="รายละเอียดเซคชัน"
-            class="mx-auto size-12! justify-center rounded-xl p-0! transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-6!"
-          >
-            <StickyNote size="24" strokeWidth={2.5} />
-          </Sidebar.MenuButton>
+          <div class="mt-[-12px]">
+            <Sidebar.MenuButton
+              onclick={() => {
+                activePanel = 'detail_only';
+                scrollToSection(detailSection);
+              }}
+              isActive={activePanel === 'detail_only'}
+              size="lg"
+              tooltipContent="รายละเอียดเซคชัน"
+              class="mx-auto size-12! justify-center rounded-xl p-0! transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-5!"
+            >
+              <StickyNote size="20" strokeWidth={2.5} />
+            </Sidebar.MenuButton>
+          </div>
         </Sidebar.MenuItem>
         <Sidebar.MenuItem>
-          <Sidebar.MenuButton
-            onclick={() => {
-              activePanel = 'review_only';
-              scrollToSection(reviewSection);
-            }}
-            isActive={activePanel === 'review_only'}
-            size="lg"
-            tooltipContent="รีวิวรายวิชา"
-            class="mx-auto size-12! justify-center rounded-xl p-0! transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-6!"
-          >
-            <MessageCircleQuestionIcon size="24" strokeWidth={2.5} />
-          </Sidebar.MenuButton>
+          <div class="mt-[-12px]">
+            <Sidebar.MenuButton
+              onclick={() => {
+                activePanel = 'review_only';
+                scrollToSection(reviewSection);
+              }}
+              isActive={activePanel === 'review_only'}
+              size="lg"
+              tooltipContent="รีวิวรายวิชา"
+              class="mx-auto size-12! justify-center rounded-xl p-0! transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-5!"
+            >
+              <MessageCircleQuestionIcon size="20" strokeWidth={2.5} />
+            </Sidebar.MenuButton>
+          </div>
         </Sidebar.MenuItem>
         {#if $session.data}
           <Sidebar.MenuItem>
-            <Sidebar.MenuButton
-              onclick={() => togglePanel('selected_only')}
-              isActive={activePanel === 'selected_only'}
-              size="lg"
-              tooltipContent="วิชาที่เลือก"
-              class="mx-auto size-12! justify-center rounded-xl p-0! transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-6!"
-            >
-              <BookMarked size="24" strokeWidth={2.5} />
-            </Sidebar.MenuButton>
+            <div class="mt-[-10px]">
+              <Sidebar.MenuButton
+                onclick={focusSelected}
+                isActive={activePanel === 'selected_only'}
+                size="lg"
+                tooltipContent="วิชาที่เลือก"
+                class="mx-auto size-12! justify-center rounded-xl p-0! transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-5!"
+              >
+                <BookMarked size="20" strokeWidth={2.5} />
+              </Sidebar.MenuButton>
+            </div>
           </Sidebar.MenuItem>
         {/if}
       {/snippet}
@@ -595,34 +631,43 @@
               academicYear={$userCart.currentCart.academicYear}
             />
           </div>
-          <hr class="mb-0 opacity-50" />
+          <hr class="mb-0 border-t border-neutral-100" />
         {/if}
 
         {#if expanded}
           <div class="text-on-surface mb-6 flex flex-col">
             <button
               type="button"
-              class="hover:text-primary w-full border-b border-gray-400 py-4 text-left text-xl font-semibold transition-colors"
-              onclick={() => scrollToSection(descriptionSection)}
+              class="hover:text-primary w-full border-b border-neutral-200 py-4 text-left text-xl font-semibold transition-colors"
+              onclick={() => {
+                activePanel = 'description_only';
+                scrollToSection(descriptionSection);
+              }}
             >
               คำอธิบายรายวิชา
             </button>
 
             <button
               type="button"
-              class="hover:text-primary w-full border-b border-gray-400 py-4 text-left text-xl font-semibold transition-colors"
-              onclick={() => scrollToSection(detailSection)}
+              class="hover:text-primary w-full border-b border-neutral-200 py-4 text-left text-xl font-semibold transition-colors"
+              onclick={() => {
+                activePanel = 'detail_only';
+                scrollToSection(detailSection);
+              }}
             >
               รายละเอียดเซคชัน
             </button>
 
             <div
-              class="flex w-full items-center justify-between border-b border-gray-400 py-3.5"
+              class="flex w-full items-center justify-between border-b border-neutral-200 py-3.5"
             >
               <button
                 type="button"
                 class="hover:text-primary text-left text-xl font-semibold transition-colors"
-                onclick={() => scrollToSection(reviewSection)}
+                onclick={() => {
+                  activePanel = 'review_only';
+                  scrollToSection(reviewSection);
+                }}
               >
                 รีวิวรายวิชา
                 <span class="text-on-surface/50 ml-1 text-sm font-normal">
@@ -651,17 +696,18 @@
             {#if $userCart.currentCart}
               <SelectedCourse
                 variant="grouped"
-                class="border-b border-neutral-200"
+                bind:open={selectedOpen}
+                class="border-b border-neutral-100"
               />
             {:else}
-              <SelectedCourse class="border-b border-neutral-200" />
+              <SelectedCourse class="border-b border-neutral-100" />
             {/if}
           </div>
         {/if}
 
         {#if expanded || openPanel === 'sidebar'}
           <div
-            class="mt-8 rounded-2xl border border-orange-300 px-5 py-4 text-center text-[15px] leading-relaxed text-orange-500"
+            class="border-secondary text-on-secondary-container mt-8 rounded-2xl border px-5 py-4 text-center text-xs/[18px]"
           >
             <span class="font-bold">CU Get Reg ไม่ใช่การลงทะเบียนเรียนจริง</span
             ><br />
@@ -1368,16 +1414,20 @@
 {#snippet SelectedContent()}
   <div bind:this={selectedSection}>
     {#if $userCart.currentCart}
-      <SelectedCourse variant="grouped" class="border-b border-neutral-200" />
+      <SelectedCourse
+        variant="grouped"
+        collapsible={false}
+        class="border-b border-neutral-100"
+      />
     {:else}
-      <SelectedCourse class="border-b border-neutral-200" />
+      <SelectedCourse collapsible={false} class="border-b border-neutral-100" />
     {/if}
   </div>
 {/snippet}
 
 {#snippet WarningContent()}
   <div
-    class="mt-8 rounded-2xl border border-orange-300 px-5 py-4 text-center text-[15px] leading-relaxed text-orange-500"
+    class="border-secondary text-on-secondary-container mt-8 rounded-2xl border px-5 py-4 text-center text-xs/[18px]"
   >
     <span class="font-bold">CU Get Reg ไม่ใช่การลงทะเบียนเรียนจริง</span><br />
     สามารถลงทะเบียนเรียนได้ที่

--- a/apps/cugetreg/src/routes/schedule/+page.svelte
+++ b/apps/cugetreg/src/routes/schedule/+page.svelte
@@ -24,9 +24,10 @@
     TIMETABLE_DEFAULT_START,
   } from '$lib/utils/schedule';
 
-  import { BookMarked, Loader2, Menu } from '@lucide/svelte';
+  import { BookMarked, Loader2, Menu, X } from '@lucide/svelte';
   import { Copy, Download } from 'lucide-svelte';
   import { getContext } from 'svelte';
+  import { fade } from 'svelte/transition';
 
   import { Button } from '@cugetreg/ui/atoms/button';
   import { CustomizeScrollbar } from '@cugetreg/ui/atoms/customize-scrollbar';
@@ -81,6 +82,8 @@
   let sidebarExpanded = $state(true);
   let openPanel = $state<'sidebar' | 'selected_only' | null>(null);
   let activePanel = $state<'sidebar' | 'selected_only' | null>(null);
+  let selectedOpen = $state(true);
+  let activeModal = $state<'selected' | null>(null);
 
   let previousCartId = $state($userCart.currentCartId);
 
@@ -125,6 +128,31 @@
       visible: isPublic ? 'PUB' : 'PVT',
     });
   }
+
+  function toggleSidebar() {
+    if (sidebarExpanded) {
+      sidebarExpanded = false;
+      activePanel = null;
+    } else {
+      sidebarExpanded = true;
+      activePanel = 'sidebar';
+      openPanel = null;
+      selectedOpen = true;
+    }
+  }
+
+  function focusSelected() {
+    if (sidebarExpanded && selectedOpen) {
+      selectedOpen = false;
+      activePanel = null;
+      return;
+    }
+    sidebarExpanded = true;
+    openPanel = null;
+    selectedOpen = true;
+    activePanel = 'selected_only';
+  }
+
 </script>
 
 <svelte:window bind:innerWidth />
@@ -211,47 +239,37 @@
   <div class="relative flex flex-1 overflow-hidden">
     <AppSidebar
       showSidebar={innerWidth >= 1024}
+      panelWidth="490px"
       bind:expanded={sidebarExpanded}
       bind:openPanel
       bind:activePanel
     >
-      {#snippet iconItems({
-        toggleExpanded,
-        togglePanel,
-        expanded,
-        openPanel,
-        activePanel,
-      })}
+      {#snippet iconItems()}
         <Sidebar.MenuItem>
           <Sidebar.MenuButton
-            onclick={toggleExpanded}
-            isActive={expanded && activePanel === 'sidebar'}
+            onclick={toggleSidebar}
+            isActive={sidebarExpanded && activePanel === 'sidebar'}
             size="lg"
             tooltipContent="ตารางเรียน"
-            class="mx-auto size-12! justify-center rounded-xl p-0! ring-0 transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-6!"
+            class="mx-auto size-12! justify-center rounded-xl p-0! ring-0 transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-5!"
           >
-            <Menu size="24" strokeWidth={2.5} />
+            <Menu size="20" strokeWidth={2.5} />
           </Sidebar.MenuButton>
         </Sidebar.MenuItem>
         <Sidebar.MenuItem>
           <Sidebar.MenuButton
-            onclick={() =>
-              togglePanel('selected_only', () => {
-                document
-                  .querySelector('[data-selected-section]')
-                  ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-              })}
+            onclick={focusSelected}
             isActive={activePanel === 'selected_only'}
             size="lg"
             tooltipContent="วิชาที่เลือก"
-            class="mx-auto size-12! justify-center rounded-xl p-0! transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-6!"
+            class="mx-auto size-12! justify-center rounded-xl p-0! transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-5!"
           >
-            <BookMarked size="24" strokeWidth={2.5} />
+            <BookMarked size="20" strokeWidth={2.5} />
           </Sidebar.MenuButton>
         </Sidebar.MenuItem>
       {/snippet}
-      {#snippet panelContent({ openPanel, expanded })}
-        {#if expanded || openPanel === 'sidebar'}
+      {#snippet panelContent({ expanded })}
+        {#if expanded}
           <div class="relative mb-6 flex flex-col gap-2">
             {#await cartPromise}
               <div
@@ -262,7 +280,7 @@
               </div>
             {:then}
               <SelectTimetable
-                class="border-b border-neutral-200 px-2 py-5"
+                class="border-b border-neutral-100 px-2 py-5"
                 options={$userCart.cartList?.map((item) => ({
                   name: item.name,
                   id: item.id,
@@ -280,40 +298,20 @@
               </div>
             {/await}
           </div>
-          <hr class="mb-6 opacity-50" />
+          <hr class="mb-6 border-t border-neutral-100" />
 
           {#if $userCart.currentCart}
             <div data-selected-section>
-              <SelectedCourse class="border-b border-neutral-200" />
+              <SelectedCourse
+                headerDivider
+                bind:open={selectedOpen}
+                class="border-b border-neutral-100"
+              />
             </div>
           {/if}
-          <hr class="mb-6 opacity-50" />
 
           <div
-            class="rounded-2xl border border-orange-300 px-5 py-4 text-center text-[15px] leading-relaxed text-orange-500"
-          >
-            <span class="font-bold">CU Get Reg ไม่ใช่การลงทะเบียนเรียนจริง</span
-            ><br />
-            สามารถลงทะเบียนเรียนได้ที่
-            <a
-              href="https://www2.reg.chula.ac.th/"
-              target="_blank"
-              rel="noreferrer"
-              class="underline">https://www2.reg.chula.ac.th/</a
-            ><br />
-            เพียงช่องทางเดียวเท่านั้น
-          </div>
-        {:else if openPanel === 'selected_only'}
-          {#if $userCart.currentCart}
-            <SelectedCourse
-              variant="grouped"
-              class="border-b border-neutral-200"
-            />
-          {:else}
-            <SelectedCourse class="border-b border-neutral-200" />
-          {/if}
-          <div
-            class="mt-8 rounded-2xl border border-orange-300 px-5 py-4 text-center text-[15px] leading-relaxed text-orange-500"
+            class="border-secondary text-on-secondary-container mt-8 rounded-2xl border px-5 py-4 text-center text-xs/[18px]"
           >
             <span class="font-bold">CU Get Reg ไม่ใช่การลงทะเบียนเรียนจริง</span
             ><br />
@@ -329,14 +327,16 @@
         {/if}
       {/snippet}
       <div class="flex min-h-full flex-col">
-        <div class="mx-auto w-full max-w-[1200px] flex-1 p-6 lg:p-10">
+        <div class="mx-auto w-full max-w-[1200px] flex-1 p-4 md:p-8 lg:p-12">
           <div
             class="flex w-full flex-col gap-4 lg:flex-row lg:items-center lg:justify-between"
           >
             <div class="flex w-full items-center justify-between lg:w-auto">
-              <span class="text-[20px] font-bold md:text-[30px] lg:text-4xl"
-                >ตารางเรียน</span
+              <h1
+                class="text-xl font-bold text-[#4A70C6] md:text-4xl md:text-black"
               >
+                ตารางเรียน
+              </h1>
               <div class="lg:hidden">
                 <Switch
                   checked={$userCart.currentCart.visible === 'PUB'}
@@ -457,4 +457,39 @@
       </div>
     </AppSidebar>
   </div>
+  <div class="lg:hidden">
+    {#if !activeModal}
+      <div transition:fade={{ duration: 200 }}>
+        <button
+          type="button"
+          aria-label="วิชาที่เลือก"
+          class="fixed right-6 bottom-6 z-50 flex h-16 w-16 items-center justify-center rounded-full bg-[#4A70C6] text-white shadow-lg transition-colors hover:bg-[#3f61ab]"
+          onclick={() => (activeModal = 'selected')}
+        >
+          <BookMarked size={28} strokeWidth={2} />
+        </button>
+      </div>
+    {/if}
+  </div>
+  {#if activeModal}
+    <div
+      class="fixed inset-0 z-[100] flex items-center justify-center bg-black/40 p-4 backdrop-blur-sm"
+      transition:fade={{ duration: 200 }}
+    >
+      <div
+        class="custom-scrollbar relative flex max-h-[85vh] w-full max-w-[400px] flex-col overflow-y-auto rounded-3xl bg-white p-6 shadow-2xl"
+      >
+        <button
+          class="absolute top-7 right-5 bg-white"
+          onclick={() => (activeModal = null)}
+        >
+          <X size={20} strokeWidth={2.5} />
+        </button>
+        <SelectedCourse
+          collapsible={false}
+          class="border-b border-neutral-100"
+        />
+      </div>
+    </div>
+  {/if}
 </div>


### PR DESCRIPTION
## Why did you create this PR
- ปรับ UI ของ sidebar ในหน้า **schedule** และ **course detail** ให้ format เหมือนหน้า **course search (Home)** เพื่อความสม่ำเสมอทั้งแอป
- แก้ปัญหา UX บน mobile: หน้า schedule ไม่มีปุ่มเปิด "วิชาที่เลือก" และปุ่มพับ/หุบใน modal ซ้อนกับปุ่มปิด
- แก้บั๊ก layout: หน้า course search มี scrollbar ซ้อนกัน 2 อัน และ sidebar มีช่องว่างขวาเยอะเกินไป

## What did you do
**Consistency (schedule + course detail ↔ Home)**
- จัด padding โครงหน้า, สไตล์ชื่อหน้า, `panelWidth="490px"`, ขนาดไอคอน sidebar, เส้นกั้น `neutral-100` และกล่อง warning ให้เหมือนกัน

**Sidebar behavior**
- ไอคอน "วิชาที่เลือก" กางเต็ม panel (ไม่เด้งเป็นก้อนลอยตอน sidebar ปิด), กดซ้ำเพื่อพับ, เปิด sidebar ด้วย hamburger แล้วกางวิชาที่เลือกเสมอ
- ปุ่มข้อความในหน้า course detail (คำอธิบายรายวิชา/รายละเอียดเซคชัน/รีวิว) ไฮไลต์ไอคอนซ้ายให้สัมพันธ์กัน
- ครอบไอคอน sidebar ด้วย `<div>` เพื่อปรับตำแหน่งขึ้น/ลงทีละอันได้

**SelectedCourse component**
- variant `detailed` ใช้หัวพับ chevron แบบเดียวกับ `grouped` (คงการลาก/เปลี่ยนสี/เซค/ซ่อนไว้ครบ)
- ซ่อน scrollbar ของรายการ, เพิ่ม prop `collapsible`

**Mobile**
- เพิ่ม FAB ในหน้า schedule กดแล้วเปิด modal "วิชาที่เลือก" ทันที
- ปิดความสามารถพับ (เอา chevron ออก) ใน mobile modal ทั้ง course search / course detail / schedule เพื่อไม่ให้ซ้อนกับปุ่มปิด

**Bug fixes**
- แก้ scrollbar ซ้อนในหน้า course search (`h-screen` → `h-full`)
- ลบ padding ขวาส่วนเกินใน `AppSidebar` ให้เนื้อหายืดเต็มความกว้าง panel

> หมายเหตุ: `svelte-check` ยังได้ 53 errors / 7 warnings เท่า baseline ก่อนแก้ (เป็น error เดิมของ repo ที่ไม่เกี่ยวกับ PR นี้) — ไม่มี error ใหม่จากการเปลี่ยนแปลง
