### PR TITLE
fix(ui): Make long course name align to the left if overflow

### DIFF
--- a/packages/ui/src/lib/components/atoms/timetable/index.ts
+++ b/packages/ui/src/lib/components/atoms/timetable/index.ts
@@ -11,7 +11,8 @@ export const timeTableCourseCardVariant = tv({
 		'left-[calc(100%/var(--cols)*var(--y))]',
 		'flex flex-col justify-center items-center',
 		'border-1 rounded-lg',
-		'hover:cursor-pointer hover:z-40 select-none'
+		'hover:cursor-pointer hover:z-40 select-none',
+		'px-2'
 	],
 	variants: {
 		color: {

--- a/packages/ui/src/lib/components/atoms/timetable/timetable-course-card.svelte
+++ b/packages/ui/src/lib/components/atoms/timetable/timetable-course-card.svelte
@@ -50,7 +50,9 @@
 	{...rest}
 >
 	<!-- NOTE: Scaling on some resolution is kinda wonky -->
-	<span class="truncate text-[15cqh]">{course.code}</span>
+	<span class="max-w-full truncate text-left text-[15cqh]">{course.code}</span>
 	<span class="max-w-full truncate text-left text-[16cqh] font-medium">{courseName}</span>
-	<span class="truncate text-[15cqh]">{course.bldg} {course.room} | Sec {course.section}</span>
+	<span class="max-w-full truncate text-left text-[15cqh]"
+		>{course.bldg} {course.room} | Sec {course.section}</span
+	>
 </div>

--- a/packages/ui/src/lib/components/atoms/timetable/timetable-course-card.svelte
+++ b/packages/ui/src/lib/components/atoms/timetable/timetable-course-card.svelte
@@ -50,16 +50,7 @@
 	{...rest}
 >
 	<!-- NOTE: Scaling on some resolution is kinda wonky -->
-	{#if length <= 1}
-		<span class="truncate text-[13cqh]">{course.code}</span>
-		<span class="w-full truncate text-left text-[15cqh] font-medium">{course.abbrName}</span>
-		<span class="w-full truncate text-center text-[13cqh]">
-			{course.bldg}
-			{course.room}
-		</span>
-	{:else}
-		<span class="truncate text-[15cqh]">{course.code}</span>
-		<span class="truncate text-[16cqh] font-medium">{courseName}</span>
-		<span class="truncate text-[15cqh]">{course.bldg} {course.room} | Sec {course.section}</span>
-	{/if}
+	<span class="truncate text-[15cqh]">{course.code}</span>
+	<span class="max-w-full truncate text-left text-[16cqh] font-medium">{courseName}</span>
+	<span class="truncate text-[15cqh]">{course.bldg} {course.room} | Sec {course.section}</span>
 </div>


### PR DESCRIPTION
## Why did you create this PR

- Make long course name align to the left if overflow

## What did you do

- Change from only make course that is less than 1 hour to apply to all course.

## Demo
<img width="1601" height="697" alt="image" src="https://github.com/user-attachments/assets/14d04940-7cd5-46a0-a283-2c42e4a938b6" />

