### PR TITLE
fix issue [CHORE] แก้ font mobile view ของเนื้อหาใน course description

### DIFF
--- a/apps/cugetreg/src/routes/course-page/[courseId]/+page.svelte
+++ b/apps/cugetreg/src/routes/course-page/[courseId]/+page.svelte
@@ -1029,7 +1029,7 @@
                     คำอธิบายรายวิชา (ภาษาไทย)
                   </p>
                 </div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {course.courseInfo.courseDescTh}
                 </p>
               </div>
@@ -1041,7 +1041,7 @@
                     คำอธิบายรายวิชา (ภาษาอังกฤษ)
                   </p>
                 </div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {course.courseInfo.courseDescEn}
                 </p>
               </div>
@@ -1065,12 +1065,12 @@
                 </div>
               </div>
               <div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {course.courseInfo.courseDescTh}
                 </p>
               </div>
               <div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {course.courseInfo.courseDescEn}
                 </p>
               </div>
@@ -1085,7 +1085,7 @@
                     คณะ
                   </p>
                 </div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {faculties[course.courseInfo.faculty ?? '']?.th ?? '-'}
                 </p>
               </div>
@@ -1097,7 +1097,7 @@
                     ภาควิชา/กลุ่มวิชา/สาขาวิชา
                   </p>
                 </div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {course.courseInfo.department}
                 </p>
               </div>
@@ -1121,12 +1121,12 @@
                 </div>
               </div>
               <div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {faculties[course.courseInfo.faculty ?? '']?.th ?? '-'}
                 </p>
               </div>
               <div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {course.courseInfo.department}
                 </p>
               </div>
@@ -1141,7 +1141,7 @@
                     รูปแบบรายวิชา
                   </p>
                 </div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {course.courseInfo.creditHours?.split(' ') ?? '-'}
                 </p>
               </div>
@@ -1153,7 +1153,7 @@
                     หน่วยกิต
                   </p>
                 </div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {course.courseInfo.credit}
                 </p>
               </div>
@@ -1177,12 +1177,12 @@
                 </div>
               </div>
               <div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {course.courseInfo.creditHours?.split(' ') ?? '-'}
                 </p>
               </div>
               <div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {course.courseInfo.credit}
                 </p>
               </div>
@@ -1197,7 +1197,7 @@
                     เงื่อนไขรายวิชา
                   </p>
                 </div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   -
                 </p>
               </div>
@@ -1209,7 +1209,7 @@
                     วิธีการวัดผล
                   </p>
                 </div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   Letter Grade
                 </p>
               </div>
@@ -1233,12 +1233,12 @@
                 </div>
               </div>
               <div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   -
                 </p>
               </div>
               <div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   Letter Grade
                 </p>
               </div>
@@ -1253,7 +1253,7 @@
                     สอบกลางภาค
                   </p>
                 </div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {midtermExam}
                 </p>
               </div>
@@ -1265,7 +1265,7 @@
                     สอบปลายภาค
                   </p>
                 </div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {finalExam}
                 </p>
               </div>
@@ -1289,12 +1289,12 @@
                 </div>
               </div>
               <div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {midtermExam}
                 </p>
               </div>
               <div>
-                <p class="text-on-surface font-sarabun text-body2 mt-3 px-4">
+                <p class="text-on-surface font-sarabun mt-3 px-4 text-sm">
                   {finalExam}
                 </p>
               </div>


### PR DESCRIPTION
## Why did you create this PR

แก้ font mobile view ของเนื้อหาใน course description

## What did you do
- Changed course description and course info text (description, faculty, department, format, credits, prerequisites, grading, exam dates) from `text-body2` to `text-sm` in `course-page/[courseId]/+page.svelte`


## Demo

https://cdn.discordapp.com/attachments/1457011091245629570/1533871569783226579/image.png?ex=6a7210b8&is=6a70bf38&hm=2060f7b71b80d68a5a0fa3a5f6a1ac9bb3824b93ae51c62c26116aa41420ff13

## Checklist

- [ yes] Deploy a demo
- [ yes] Check browsers compatibility
- [ yes] Wrote coverage tests

<!--
## Related links
-
-->
