### PR TITLE
Fix: export buttons UI

### DIFF
--- a/apps/cugetreg/src/lib/components/exams-list.svelte
+++ b/apps/cugetreg/src/lib/components/exams-list.svelte
@@ -145,9 +145,14 @@
 {/if}
 
 <div class="mt-4 flex justify-end">
-  <Button class="m-0 flex items-center gap-1" onclick={handleDownloadICS}>
-    <Download size={18} strokeWidth={2} />
-    ตารางสอบ (.ics)
+  <Button
+    variant="outlined"
+    color="neutral"
+    class="m-0 gap-2"
+    onclick={handleDownloadICS}
+  >
+    <Download size={18} strokeWidth={2.5} />
+    ตารางสอบ (.ICS)
   </Button>
 </div>
 

--- a/apps/cugetreg/src/routes/schedule/+page.svelte
+++ b/apps/cugetreg/src/routes/schedule/+page.svelte
@@ -165,6 +165,18 @@
 
 <svelte:window bind:innerWidth />
 
+{#snippet screenshotButton(visibility: string)}
+  <Button
+    variant="outlined"
+    color="neutral"
+    class="m-0 gap-2 {visibility}"
+    onclick={handleTimetableScreenshot}
+  >
+    <Download size={18} strokeWidth={2.5} />
+    บันทึกภาพ
+  </Button>
+{/snippet}
+
 <div class="relative flex h-full flex-col overflow-hidden bg-white">
   <Modal
     exitOnEsc
@@ -411,19 +423,7 @@
                 onCheckedChange={handlePublicToggle}
                 label="เปิดเป็นสาธารณะ"
               />
-              {#if innerWidth < 1024}
-                <Button
-                  class="m-0 flex items-center gap-1 border border-gray-200 bg-white"
-                  onclick={handleTimetableScreenshot}
-                >
-                  <Download
-                    size={20}
-                    strokeWidth={2.5}
-                    class="text-[#353745]"
-                  />
-                  <span class="font-medium text-[#353745]">บันทึกภาพ</span>
-                </Button>
-              {/if}
+              {@render screenshotButton('lg:hidden')}
             </div>
             <div class="flex w-full items-center gap-2 lg:flex-1">
               <div class="relative flex flex-1">
@@ -451,11 +451,7 @@
               <!-- <IconButton class="aspect-square"> -->
               <!--   <Share2 /> -->
               <!-- </IconButton> -->
-              {#if innerWidth >= 1024}
-                <Button class="m-0" onclick={handleTimetableScreenshot}>
-                  บันทึกเป็นภาพ
-                </Button>
-              {/if}
+              {@render screenshotButton('hidden lg:inline-flex')}
             </div>
           </div>
           <ExamsList cart={$userCart.currentCart} exams={$userCart.exams} />


### PR DESCRIPTION
## Why did you create this PR

- fix export buttons UI in time-table page
- Resolves #1066 

## What did you do

- fix export buttons UI in time-table page

## Demo

Desktop
<img width="1920" height="963" alt="Screenshot From 2026-08-08 21-52-45" src="https://github.com/user-attachments/assets/44c893b5-f1bf-49e0-af47-c3cf71013d5b" />

Moblie
<img width="450" height="794" alt="Screenshot From 2026-08-08 21-53-08" src="https://github.com/user-attachments/assets/de293351-2546-42a2-9a9f-6b4674bf206f" />

