### PR TITLE
docs: document pre-commit hook installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+## Development setup
+
+This repo uses [pre-commit](https://pre-commit.com/) for git hooks (gitleaks secret
+scanning, YAML/whitespace checks, conventional commit messages) — see
+`.pre-commit-config.yaml`.
+
+It installs itself automatically via `pnpm install` (see the `prepare` script in
+`package.json`), as long as `pre-commit` is already on your `PATH`. To install it
+manually:
+
+```bash
+pip install pre-commit  # or: brew install pre-commit
+pre-commit install
+pre-commit install --hook-type commit-msg
+```
+
+The second command is required separately — `conventional-pre-commit` runs at the
+`commit-msg` stage, not the default `pre-commit` stage.


### PR DESCRIPTION
## Summary

Cherry-pick of a docs-only commit that's been on the fork (`narumedsr-p/cugetregv2`) since Aug 7 but never made it upstream — `README.md` here is still empty.

Documents how `pre-commit` (gitleaks secret scanning, YAML/whitespace checks, conventional commit messages — see `.pre-commit-config.yaml`) gets installed: automatically via the `prepare` script in `package.json` if `pre-commit` is already on `PATH`, plus manual install steps and the separate `commit-msg` hook install that's easy to miss.

No code changes.