### PR TITLE
Fixed sidebar for all page

### DIFF
--- a/apps/cugetreg/src/lib/components/app-sidebar.svelte
+++ b/apps/cugetreg/src/lib/components/app-sidebar.svelte
@@ -81,7 +81,7 @@
             ></div>
           {/if}
           <div
-            class="bg-surface flex flex-1 flex-col overflow-hidden border-r border-neutral-100 group-data-[state=collapsed]:absolute group-data-[state=collapsed]:border group-data-[state=collapsed]:top-4 group-data-[state=collapsed]:left-[calc(var(--sidebar-width-icon)+1rem)] group-data-[state=collapsed]:z-50 group-data-[state=collapsed]:max-h-[min(800px,calc(100%-2rem))] group-data-[state=collapsed]:w-[400px] group-data-[state=collapsed]:rounded-3xl group-data-[state=collapsed]:shadow-2xl md:px-2 md:pt-0 md:pb-8"
+            class="bg-surface flex flex-1 flex-col overflow-hidden border-r border-neutral-100 group-data-[state=collapsed]:absolute group-data-[state=collapsed]:top-4 group-data-[state=collapsed]:left-[calc(var(--sidebar-width-icon)+1rem)] group-data-[state=collapsed]:z-50 group-data-[state=collapsed]:max-h-[min(800px,calc(100%-2rem))] group-data-[state=collapsed]:w-[400px] group-data-[state=collapsed]:rounded-3xl group-data-[state=collapsed]:border group-data-[state=collapsed]:shadow-2xl md:px-2 md:pt-0 md:pb-8"
           >
             <div
               class="flex-1 overflow-y-auto pb-10 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"

--- a/apps/cugetreg/src/lib/components/app-sidebar.svelte
+++ b/apps/cugetreg/src/lib/components/app-sidebar.svelte
@@ -45,7 +45,7 @@
     >
       <Sidebar.Content class="flex-row overflow-visible!">
         <Sidebar.Group
-          class="w-(--sidebar-width-icon) shrink-0 items-center border-r-neutral-100 bg-white p-0 pt-[1rem] pb-6 group-data-[variant=floating]:rounded-l-lg md:pt-[1.5rem]"
+          class="w-(--sidebar-width-icon) shrink-0 items-center border-r border-r-neutral-100 bg-white p-0 pt-[1rem] pb-6 group-data-[variant=floating]:rounded-l-lg md:pt-[1.5rem]"
         >
           <Sidebar.GroupContent>
             <Sidebar.Menu class="gap-6">
@@ -81,7 +81,7 @@
             ></div>
           {/if}
           <div
-            class="bg-surface flex flex-1 flex-col overflow-hidden border border-neutral-100 group-data-[state=collapsed]:absolute group-data-[state=collapsed]:top-4 group-data-[state=collapsed]:left-[calc(var(--sidebar-width-icon)+1rem)] group-data-[state=collapsed]:z-50 group-data-[state=collapsed]:max-h-[min(800px,calc(100%-2rem))] group-data-[state=collapsed]:w-[400px] group-data-[state=collapsed]:rounded-3xl group-data-[state=collapsed]:shadow-2xl md:px-2 md:pt-0 md:pb-8"
+            class="bg-surface flex flex-1 flex-col overflow-hidden border-r border-neutral-100 group-data-[state=collapsed]:absolute group-data-[state=collapsed]:border group-data-[state=collapsed]:top-4 group-data-[state=collapsed]:left-[calc(var(--sidebar-width-icon)+1rem)] group-data-[state=collapsed]:z-50 group-data-[state=collapsed]:max-h-[min(800px,calc(100%-2rem))] group-data-[state=collapsed]:w-[400px] group-data-[state=collapsed]:rounded-3xl group-data-[state=collapsed]:shadow-2xl md:px-2 md:pt-0 md:pb-8"
           >
             <div
               class="flex-1 overflow-y-auto pb-10 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"

--- a/apps/cugetreg/src/routes/Home.svelte
+++ b/apps/cugetreg/src/routes/Home.svelte
@@ -678,7 +678,7 @@
           opened or closed. Tune the three values if the headers change height.
         -->
         <Sidebar.MenuItem>
-          <div class="-mt-[5px]">
+          <div class="-mt-[0px]">
             <Sidebar.MenuButton
               onclick={toggleSidebar}
               isActive={sidebarExpanded && activePanel === 'sidebar'}
@@ -691,7 +691,7 @@
           </div>
         </Sidebar.MenuItem>
         <Sidebar.MenuItem>
-          <div class="mt-[5px]">
+          <div class="mt-[18px]">
             <Sidebar.MenuButton
               onclick={focusFilter}
               isActive={activePanel === 'filter_only'}
@@ -724,14 +724,14 @@
           <div class="relative mb-6 flex flex-col gap-2">
             {#await cartPromise}
               <div
-                class="flex items-center justify-center gap-2 border-b border-neutral-100 px-2 py-8 text-gray-400"
+                class="flex items-center justify-center gap-2 px-2 py-8 text-gray-400"
               >
                 <Loader2 class="animate-spin" size={24} />
                 <span class="text-sm">กำลังโหลดตารางเรียน...</span>
               </div>
             {:then}
               <SelectTimetable
-                class="border-b border-neutral-100 px-2 py-5"
+                class="px-2 pt-5"
                 options={$userCart.cartList?.map((item) => ({
                   name: item.name,
                   id: item.id,
@@ -743,7 +743,7 @@
               />
             {:catch}
               <div
-                class="flex items-center justify-center gap-2 border-b border-neutral-100 px-2 py-8 text-sm text-red-400"
+                class="flex items-center justify-center gap-2 px-2 py-8 text-sm text-red-400"
               >
                 โหลดตารางเรียนไม่สำเร็จ
               </div>

--- a/apps/cugetreg/src/routes/course-page/+page.svelte
+++ b/apps/cugetreg/src/routes/course-page/+page.svelte
@@ -1109,7 +1109,7 @@
   >
     <Sidebar.Content class="flex-row overflow-visible!">
       <Sidebar.Group
-        class="w-(--sidebar-width-icon) shrink-0 items-center border-r bg-white p-0 pt-[1rem] pb-6 group-data-[variant=floating]:rounded-l-lg md:pt-[1.5rem]"
+        class="w-(--sidebar-width-icon) shrink-0 items-center border-r border-r-neutral-100 bg-white p-0 pt-[1rem] pb-6 group-data-[variant=floating]:rounded-l-lg md:pt-[1.5rem]"
       >
         <Sidebar.GroupContent>
           <Sidebar.Menu class="gap-6">
@@ -1183,7 +1183,7 @@
           ></div>
         {/if}
         <div
-          class="bg-surface flex flex-1 flex-col overflow-hidden group-data-[state=collapsed]:absolute group-data-[state=collapsed]:top-4 group-data-[state=collapsed]:left-[calc(var(--sidebar-width-icon)+1rem)] group-data-[state=collapsed]:z-50 group-data-[state=collapsed]:max-h-[min(800px,calc(100%-2rem))] group-data-[state=collapsed]:w-[400px] group-data-[state=collapsed]:rounded-3xl group-data-[state=collapsed]:border group-data-[state=collapsed]:shadow-2xl md:px-8 md:pt-0 md:pb-8"
+          class="bg-surface flex flex-1 flex-col overflow-hidden border-r border-neutral-100 group-data-[state=collapsed]:absolute group-data-[state=collapsed]:top-4 group-data-[state=collapsed]:left-[calc(var(--sidebar-width-icon)+1rem)] group-data-[state=collapsed]:z-50 group-data-[state=collapsed]:max-h-[min(800px,calc(100%-2rem))] group-data-[state=collapsed]:w-[400px] group-data-[state=collapsed]:rounded-3xl group-data-[state=collapsed]:border group-data-[state=collapsed]:border-neutral-100 group-data-[state=collapsed]:shadow-2xl md:px-8 md:pt-0 md:pb-8"
         >
           <div class="flex-1 overflow-y-auto pr-6 pb-10 md:pr-8">
             {#if sidebarExpanded || openPanel === 'sidebar'}
@@ -1192,7 +1192,7 @@
                 class="relative mb-6 flex flex-col gap-2"
               >
                 <SelectTimetable
-                  class="border-b border-neutral-200 px-2 py-5"
+                  class="px-2 pt-5"
                   options={$userCart.cartList?.map((item) => ({
                     name: item.name,
                     id: item.id,
@@ -1203,7 +1203,7 @@
                   academicYear={$userCart.currentCart.academicYear}
                 />
               </div>
-              <hr class="mb-0 opacity-50" />
+              <hr class="mb-0 border-t border-neutral-100" />
             {/if}
 
             {#if sidebarExpanded}

--- a/apps/cugetreg/src/routes/course-page/[courseId]/+page.svelte
+++ b/apps/cugetreg/src/routes/course-page/[courseId]/+page.svelte
@@ -782,7 +782,7 @@
           </div>
         </Sidebar.MenuItem>
         <Sidebar.MenuItem>
-          <div class="mt-[0px]">
+          <div class="mt-[-8px]">
             <Sidebar.MenuButton
               onclick={() => {
                 activePanel = 'description_only';
@@ -798,7 +798,7 @@
           </div>
         </Sidebar.MenuItem>
         <Sidebar.MenuItem>
-          <div class="mt-[-12px]">
+          <div class="mt-[-20px]">
             <Sidebar.MenuButton
               onclick={() => {
                 activePanel = 'detail_only';
@@ -814,7 +814,7 @@
           </div>
         </Sidebar.MenuItem>
         <Sidebar.MenuItem>
-          <div class="mt-[-12px]">
+          <div class="mt-[-15px]">
             <Sidebar.MenuButton
               onclick={() => {
                 activePanel = 'review_only';
@@ -870,7 +870,7 @@
           <div class="text-on-surface mb-6 flex flex-col">
             <button
               type="button"
-              class="hover:text-primary w-full border-b border-neutral-200 py-4 text-left text-xl font-semibold transition-colors"
+              class="hover:text-primary w-full border-b border-neutral-200 py-4 text-left text-lg/[20px] font-medium transition-colors"
               onclick={() => {
                 activePanel = 'description_only';
                 scrollToSection(descriptionSection);
@@ -881,7 +881,7 @@
 
             <button
               type="button"
-              class="hover:text-primary w-full border-b border-neutral-200 py-4 text-left text-xl font-semibold transition-colors"
+              class="hover:text-primary w-full border-b border-neutral-200 py-4 text-left text-lg/[20px] font-medium transition-colors"
               onclick={() => {
                 activePanel = 'detail_only';
                 scrollToSection(detailSection);
@@ -895,7 +895,7 @@
             >
               <button
                 type="button"
-                class="hover:text-primary text-left text-xl font-semibold transition-colors"
+                class="hover:text-primary text-left text-lg/[20px] font-medium transition-colors"
                 onclick={() => {
                   activePanel = 'review_only';
                   scrollToSection(reviewSection);

--- a/apps/cugetreg/src/routes/schedule/+page.svelte
+++ b/apps/cugetreg/src/routes/schedule/+page.svelte
@@ -254,27 +254,37 @@
       bind:activePanel
     >
       {#snippet iconItems()}
+        <!--
+          Each icon is nudged with a fixed margin so it lines up with its
+          section header in the panel. These are pure layout offsets: nothing
+          recomputes them, so the icons never shift when a section is opened or
+          closed. Tune the two values if the headers change height.
+        -->
         <Sidebar.MenuItem>
-          <Sidebar.MenuButton
-            onclick={toggleSidebar}
-            isActive={sidebarExpanded && activePanel === 'sidebar'}
-            size="lg"
-            tooltipContent="ตารางเรียน"
-            class="mx-auto size-12! justify-center rounded-xl p-0! ring-0 transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-5!"
-          >
-            <Menu size="20" strokeWidth={2.5} />
-          </Sidebar.MenuButton>
+          <div class="mt-[0px]">
+            <Sidebar.MenuButton
+              onclick={toggleSidebar}
+              isActive={sidebarExpanded && activePanel === 'sidebar'}
+              size="lg"
+              tooltipContent="ตารางเรียน"
+              class="mx-auto size-12! justify-center rounded-xl p-0! ring-0 transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-5!"
+            >
+              <Menu size="20" strokeWidth={2.5} />
+            </Sidebar.MenuButton>
+          </div>
         </Sidebar.MenuItem>
         <Sidebar.MenuItem>
-          <Sidebar.MenuButton
-            onclick={focusSelected}
-            isActive={activePanel === 'selected_only'}
-            size="lg"
-            tooltipContent="วิชาที่เลือก"
-            class="mx-auto size-12! justify-center rounded-xl p-0! transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-5!"
-          >
-            <BookMarked size="20" strokeWidth={2.5} />
-          </Sidebar.MenuButton>
+          <div class="mt-[18px]">
+            <Sidebar.MenuButton
+              onclick={focusSelected}
+              isActive={activePanel === 'selected_only'}
+              size="lg"
+              tooltipContent="วิชาที่เลือก"
+              class="mx-auto size-12! justify-center rounded-xl p-0! transition-all data-[active=true]:bg-[#E9EEF6] data-[active=true]:text-[#004494] [&>svg]:size-5!"
+            >
+              <BookMarked size="20" strokeWidth={2.5} />
+            </Sidebar.MenuButton>
+          </div>
         </Sidebar.MenuItem>
       {/snippet}
       {#snippet panelContent({ expanded })}
@@ -289,7 +299,7 @@
               </div>
             {:then}
               <SelectTimetable
-                class="border-b border-neutral-100 px-2 py-5"
+                class="px-2 pt-5"
                 options={$userCart.cartList?.map((item) => ({
                   name: item.name,
                   id: item.id,


### PR DESCRIPTION
## Why did you create this PR

- แก้เส้นกั้นใต้ตัวเลือกตารางเรียนใน sidebar ซ้ำกันสองเส้น
- เส้นกั้นแนวตั้งของ sidebar ไม่ขึ้น
- สีเส้นกั้นไม่ตรงกันในแต่ละหน้า
- หัวข้อใน sidebar หน้า course detail ขนาดและน้ำหนักฟอนต์ไม่เท่ากับ "วิชาที่เลือก"
- หน้า schedule ไม่มีจุดปรับตำแหน่งไอคอน sidebar เหมือนอีกสองหน้า

## What did you do

- ลบเส้นซ้ำใต้ตัวเลือกตารางเรียน เหลือ `<hr>` เส้นเดียว
- แก้เส้นกั้นแนวตั้งให้ขึ้นครบทุกหน้า ทั้งตอนเปิดและปิด sidebar
- ปรับสีเส้นกั้นทุกเส้นให้เป็น `neutral-100` เหมือนกันหมด
- ปรับหัวข้อทั้งสามในหน้า course detail ให้เท่ากับ "วิชาที่เลือก"
- เพิ่มจุดปรับตำแหน่งไอคอนให้หน้า schedule และจูนระยะให้ไอคอนตรงกับหัวข้อทั้งสามหน้า

## Demo

https://github.com/user-attachments/assets/98a95c30-e4d3-4c65-8e0b-f65ba4c34200

