### PR TITLE
feat(frontend): filter not GenEd option

### DIFF
--- a/packages/ui/src/lib/components/organisms/filter-bar/filter.svelte
+++ b/packages/ui/src/lib/components/organisms/filter-bar/filter.svelte
@@ -14,7 +14,8 @@
 		{ id: 'SC', label: 'วิทย์', color: '#E39600', bg: '#FFFFFF' },
 		{ id: 'HU', label: 'มนุษย์', color: '#C7117F', bg: '#FFFFFF' },
 		{ id: 'SO', label: 'สังคม', color: '#4B991C', bg: '#FFFFFF' },
-		{ id: 'IN', label: 'สหฯ', color: '#681A83', bg: '#FFFFFF' }
+		{ id: 'IN', label: 'สหฯ', color: '#681A83', bg: '#FFFFFF' },
+		{ id: 'NO', label: 'ไม่ใช่ GenEd', color: '#000000', bg: '#FFFFFF' }
 	];
 
 	const facultyOptions = Object.keys(FACULTIES).map((faculty) => {


### PR DESCRIPTION
## Why did you create this PR

- user can filter courses which are not GenEd.

## What did you do

- add not GenEd filter option
- Resolves #1059 

## Checklist
<img width="1920" height="989" alt="Screenshot From 2026-08-15 16-36-21" src="https://github.com/user-attachments/assets/bd298cff-063a-47e1-a36e-4d7433db0d96" />
<img width="1920" height="989" alt="Screenshot From 2026-08-15 16-36-29" src="https://github.com/user-attachments/assets/09edf58b-b7bd-456e-bd6b-9f04a2745567" />
<img width="1920" height="989" alt="Screenshot From 2026-08-15 16-36-44" src="https://github.com/user-attachments/assets/ba22b2d2-79de-47ae-956f-9bd182bc426f" />
<img width="1920" height="989" alt="Screenshot From 2026-08-15 16-36-52" src="https://github.com/user-attachments/assets/2895fb3f-5091-4578-b470-7fa4b3efb76b" />
<img width="1920" height="989" alt="Screenshot From 2026-08-15 16-37-05" src="https://github.com/user-attachments/assets/3b66918f-dcbe-48a5-ad29-502ad0e4784b" />

