### PR TITLE
feat: seat เต็มเป็นสีแดง + ลบรีวิวได้ทุกสถานะ

### DIFF
--- a/apps/core/src/services/coursesService.ts
+++ b/apps/core/src/services/coursesService.ts
@@ -356,6 +356,7 @@ async function getCourseReviewByCourseNo(
   };
   const reviewSelect = {
     id: true,
+    userId: true,
     rating: true,
     status: true,
     studyProgram: true,
@@ -476,9 +477,11 @@ async function getCourseReviewByCourseNo(
     const dislikeCount =
       reviewVotes.find((v) => v.voteType === VoteType.D)?._count._all ?? 0;
     const reaction = reactions.get(review.id);
+    // Never expose the author's userId — only whether it is the caller's own.
+    const { userId: reviewUserId, ...publicReview } = review;
 
     return {
-      ...review,
+      ...publicReview,
       user: {
         ...review.user,
         faculty: unmapFacultyCode(review.user.faculty),
@@ -487,6 +490,7 @@ async function getCourseReviewByCourseNo(
         likeCount,
         dislikeCount,
       },
+      isOwner: userId !== undefined && reviewUserId === userId,
       ...(reaction && { reaction }),
     } as CourseReview;
   });

--- a/apps/cugetreg/src/routes/course-page/[courseId]/+page.svelte
+++ b/apps/cugetreg/src/routes/course-page/[courseId]/+page.svelte
@@ -43,9 +43,11 @@
   import * as Accordion from '@cugetreg/ui/atoms/accordion';
   import { Button } from '@cugetreg/ui/atoms/button';
   import { GenedChip } from '@cugetreg/ui/atoms/gened-chip';
+  import { Modal } from '@cugetreg/ui/atoms/modal';
   import { StudyProgramChip } from '@cugetreg/ui/atoms/studyprogram-chip';
   import { YearSemesterChip } from '@cugetreg/ui/atoms/yearsemester-chip';
   import { Comment } from '@cugetreg/ui/molecules/comment';
+  import { ConfirmDeleteReview } from '@cugetreg/ui/molecules/confirm-delete-review';
   import { FloatingButton } from '@cugetreg/ui/molecules/floating-button';
   import {
     type ClassInfo,
@@ -599,19 +601,38 @@
     }
   }
 
-  async function handleDeleteReview(reviewId: string) {
-    const isConfirm = confirm('Confirm Delete?');
-    if (!isConfirm) return;
+  let editingReviewId = $state<string | null>(null);
+  let deletingReviewId = $state<string | null>(null);
+  let reviewDeleting = $state(false);
+
+  function requestDeleteReview(reviewId: string) {
+    deletingReviewId = reviewId;
+  }
+
+  async function confirmDeleteReview() {
+    const reviewId = deletingReviewId;
+    if (!reviewId || reviewDeleting) return;
+    reviewDeleting = true;
+
     try {
       await api.delete(`/reviews/${reviewId}`);
+      // The deleted review may have been the one loaded into the write-review
+      // form, so drop the edit target along with it.
+      if (editingReviewId === reviewId) {
+        editingReviewId = null;
+        reviewContent = '';
+        reviewRating = 1;
+      }
+      deletingReviewId = null;
       await refreshReviews({ includeFacets: true });
       toast.success('ลบรีวิวสำเร็จ', { position: 'bottom-right' });
     } catch (error) {
       console.error(error);
+      toast.error('ไม่สามารถลบรีวิวได้', { position: 'bottom-right' });
+    } finally {
+      reviewDeleting = false;
     }
   }
-
-  let editingReviewId = $state<string | null>(null);
 
   function handleEditReview(review: any) {
     reviewRating = review.rating / 2;
@@ -1417,6 +1438,27 @@
             </Accordion.Root>
           </section>
 
+          <Modal
+            exitOnEsc
+            exitOnBackgroundClick
+            centered
+            dim
+            bind:show={
+              () => deletingReviewId !== null,
+              (show) => {
+                if (!show && !reviewDeleting) deletingReviewId = null;
+              }
+            }
+          >
+            <ConfirmDeleteReview
+              loading={reviewDeleting}
+              onCancel={() => {
+                if (!reviewDeleting) deletingReviewId = null;
+              }}
+              onConfirm={confirmDeleteReview}
+            />
+          </Modal>
+
           {#if showMismatchPopup}
             <ScheduleMismatchPopup
               schedules={$userCart.cartList ?? []}
@@ -1728,12 +1770,13 @@
                     likesCount={review.stats.likeCount}
                     dislikesCount={review.stats.dislikeCount}
                     status={review.status}
+                    isOwner={review.isOwner}
                     facultyMajor={affiliation || undefined}
                     onLike={() => handleReactReview(review.id, 'L')}
                     onDislike={() => handleReactReview(review.id, 'D')}
                     reaction={review.reaction}
                     onEdit={() => handleEditReview(review)}
-                    onDelete={() => handleDeleteReview(review.id)}
+                    onDelete={() => requestDeleteReview(review.id)}
                   />
                 {/each}
               </div>

--- a/packages/ui/src/lib/components/molecules/comment/comment.stories.svelte
+++ b/packages/ui/src/lib/components/molecules/comment/comment.stories.svelte
@@ -22,9 +22,21 @@
 			},
 			dislikesCount: {
 				control: 'number'
+			},
+			isOwner: {
+				control: 'boolean'
+			},
+			status: {
+				control: {
+					type: 'select'
+				},
+				options: ['PENDING', 'APPROVED', 'REJECTED']
 			}
 		}
 	});
+
+	const sampleContent = `ส่วนตัวคิดว่าค่อนข้างสบาย
+มีงานสัปดาห์ละครั้ง ปกติจะมีวิดีโอให้ดู ไม่ยาวมาก แต่จะไม่ดูก็ได้ เพราะปกติเราแค่อ่านตัวอย่างที่ให้มาแล้วก็ลองเขียนเลย`;
 </script>
 
 <Story
@@ -41,5 +53,52 @@ Topic กว้างๆมา ถ้าอาจารย์ประจำ sec
 		rating: 3.5,
 		likesCount: 100,
 		dislikesCount: 0
+	}}
+/>
+
+<!-- Owners get the delete button on every moderation status; edit stays
+	 rejected-only, so this approved review shows the trash icon alone. -->
+<Story
+	name="Owned - Approved"
+	args={{
+		content: sampleContent,
+		semester: `ภาคต้น 2565`,
+		year: 2565,
+		section: 1,
+		rating: 4,
+		likesCount: 0,
+		dislikesCount: 0,
+		status: 'APPROVED',
+		isOwner: true
+	}}
+/>
+
+<Story
+	name="Owned - Pending"
+	args={{
+		content: sampleContent,
+		semester: `ภาคต้น 2565`,
+		year: 2565,
+		section: 1,
+		rating: 4,
+		likesCount: 0,
+		dislikesCount: 0,
+		status: 'PENDING',
+		isOwner: true
+	}}
+/>
+
+<Story
+	name="Owned - Rejected"
+	args={{
+		content: sampleContent,
+		semester: `ภาคต้น 2565`,
+		year: 2565,
+		section: 1,
+		rating: 4,
+		likesCount: 0,
+		dislikesCount: 0,
+		status: 'REJECTED',
+		isOwner: true
 	}}
 />

--- a/packages/ui/src/lib/components/molecules/comment/comment.svelte
+++ b/packages/ui/src/lib/components/molecules/comment/comment.svelte
@@ -18,6 +18,8 @@
 		facultyMajor?: string;
 		reaction?: 'L' | 'D';
 		status: 'REJECTED' | 'PENDING' | 'APPROVED';
+		/** Whether the review belongs to the current user. */
+		isOwner?: boolean;
 
 		onLike: () => void;
 		onDislike: () => void;
@@ -35,6 +37,7 @@
 		dislikesCount,
 		facultyMajor,
 		status,
+		isOwner = false,
 
 		reaction,
 
@@ -43,6 +46,11 @@
 		onEdit,
 		onDelete
 	}: CommentProps = $props();
+
+	// Owners can remove their review whatever its moderation status; editing
+	// only makes sense once it has been rejected.
+	const canDelete = $derived(isOwner && Boolean(onDelete));
+	const canEdit = $derived(isOwner && status === 'REJECTED' && Boolean(onEdit));
 	let hasHalfStar: boolean = $derived(rating % 1 !== 0); // Determine if there's a half star
 	let isExpanded: boolean = $state(false);
 
@@ -168,22 +176,26 @@
 				{dislikesCount}
 			</div>
 		</div>
-		{#if status === 'REJECTED'}
+		{#if canDelete || canEdit}
 			<div class="flex flex-row items-center gap-3">
-				<button
-					class="rounded-md p-1 transition-colors hover:cursor-pointer hover:bg-red-50"
-					aria-label="Delete review"
-					onclick={onDelete}
-				>
-					<Trash2 size={20} class="text-[#FF4D4F]" />
-				</button>
-				<button
-					class="rounded-md p-1 transition-colors hover:cursor-pointer hover:bg-blue-50"
-					aria-label="Edit review"
-					onclick={onEdit}
-				>
-					<Pencil size={20} class="text-[#4A70C6]" />
-				</button>
+				{#if canDelete}
+					<button
+						class="rounded-md p-1 transition-colors hover:cursor-pointer hover:bg-red-50"
+						aria-label="Delete review"
+						onclick={onDelete}
+					>
+						<Trash2 size={20} class="text-[#FF4D4F]" />
+					</button>
+				{/if}
+				{#if canEdit}
+					<button
+						class="rounded-md p-1 transition-colors hover:cursor-pointer hover:bg-blue-50"
+						aria-label="Edit review"
+						onclick={onEdit}
+					>
+						<Pencil size={20} class="text-[#4A70C6]" />
+					</button>
+				{/if}
 			</div>
 		{/if}
 	</div>

--- a/packages/ui/src/lib/components/molecules/confirm-delete-review/confirm-delete-review.stories.svelte
+++ b/packages/ui/src/lib/components/molecules/confirm-delete-review/confirm-delete-review.stories.svelte
@@ -1,0 +1,44 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+
+	import { ConfirmDeleteReview } from './index.js';
+
+	const { Story } = defineMeta({
+		title: 'Molecule/Confirm Delete Review',
+		component: ConfirmDeleteReview,
+		tags: ['autodocs'],
+		argTypes: {
+			variant: {
+				control: {
+					type: 'select'
+				},
+				options: ['overlay', 'card'],
+				defaultValue: 'card'
+			},
+			loading: {
+				control: 'boolean'
+			},
+			onCancel: {
+				action: 'onCancel'
+			},
+			onConfirm: {
+				action: 'onConfirm'
+			}
+		}
+	});
+</script>
+
+<Story
+	name="Default"
+	args={{
+		variant: 'card'
+	}}
+/>
+
+<Story
+	name="Loading"
+	args={{
+		variant: 'card',
+		loading: true
+	}}
+/>

--- a/packages/ui/src/lib/components/molecules/confirm-delete-review/confirm-delete-review.svelte
+++ b/packages/ui/src/lib/components/molecules/confirm-delete-review/confirm-delete-review.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import { Button } from '../../atoms/button';
+
+	interface Props {
+		onCancel?: () => void;
+		onConfirm?: () => void;
+		variant?: 'overlay' | 'card';
+		loading?: boolean;
+	}
+
+	let { onCancel, onConfirm, variant = 'overlay', loading = false }: Props = $props();
+
+	const handleCancel = () => {
+		onCancel?.();
+	};
+
+	const handleConfirm = () => {
+		onConfirm?.();
+	};
+
+	const wrapperClass = $derived(
+		variant === 'overlay'
+			? 'fixed inset-0 flex items-center justify-center bg-surface-container-highest/60 p-4'
+			: 'w-full flex items-center justify-center p-4'
+	);
+</script>
+
+<div class={wrapperClass} role="presentation">
+	<div
+		class="border-surface-container-low bg-surface w-full max-w-md rounded-2xl border-2 px-8 py-10 text-center shadow-[0_10px_30px_rgba(0,0,0,0.15)]"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="delete-review-title"
+		aria-describedby="delete-review-description"
+	>
+		<h2 id="delete-review-title" class="text-h2 text-on-surface font-bold">ลบรีวิวนี้</h2>
+		<p id="delete-review-description" class="text-body2 text-on-surface/70 mt-4 font-medium">
+			คุณต้องการลบรีวิวนี้<br />
+			ใช่หรือไม่
+		</p>
+		<div class="mt-8 flex items-center justify-center gap-4">
+			<Button color="neutral" class="h-9 w-32" onclick={handleCancel} disabled={loading}>
+				ยกเลิก
+			</Button>
+			<Button color="error" class="h-9 w-32" onclick={handleConfirm} disabled={loading}>
+				{loading ? 'กำลังลบ...' : 'ลบรีวิว'}
+			</Button>
+		</div>
+	</div>
+</div>

--- a/packages/ui/src/lib/components/molecules/confirm-delete-review/index.ts
+++ b/packages/ui/src/lib/components/molecules/confirm-delete-review/index.ts
@@ -1,0 +1,7 @@
+import Root from './confirm-delete-review.svelte';
+
+export {
+	//
+	Root as ConfirmDeleteReview,
+	Root
+};

--- a/packages/ui/src/lib/components/molecules/course-card/course-card.stories.svelte
+++ b/packages/ui/src/lib/components/molecules/course-card/course-card.stories.svelte
@@ -91,3 +91,20 @@
 		favorite: true
 	}}
 />
+
+<!--👇 Enrolled >= capacity turns the seat count red-->
+<Story
+	name="Seats Full"
+	args={{
+		course: {
+			code: '2109101',
+			name: 'ENG MATERIALS',
+			credit: 3,
+			gened: [],
+			seat: 132,
+			maxseat: 130,
+			review: 0,
+			days: ['MO', 'WE']
+		}
+	}}
+/>

--- a/packages/ui/src/lib/components/molecules/course-card/course-card.svelte
+++ b/packages/ui/src/lib/components/molecules/course-card/course-card.svelte
@@ -55,6 +55,10 @@
 		selected = !selected;
 	};
 
+	const isSeatFull = $derived(
+		course?.seat !== undefined && course?.maxseat !== undefined && course.seat >= course.maxseat
+	);
+
 	const onFavoriteClick = (event?: MouseEvent) => {
 		event?.stopPropagation();
 		if (onToggleFavorite) {
@@ -98,7 +102,9 @@
 		<div class="text-caption flex flex-row items-center font-normal text-neutral-400">
 			<span>{course?.credit} หน่วยกิต</span>
 			<Dot color="#EDEDF1" size="16" />
-			<span>ที่นั่ง {course?.seat} / {course?.maxseat}</span>
+			<span class={isSeatFull ? 'text-red-500' : undefined}
+				>ที่นั่ง {course?.seat} / {course?.maxseat}</span
+			>
 			<Dot color="#EDEDF1" size="16" />
 			<span>{course?.review} รีวิว</span>
 		</div>

--- a/packages/zod-schemas/courses.response.schema.ts
+++ b/packages/zod-schemas/courses.response.schema.ts
@@ -100,6 +100,9 @@ export const CourseReview = z.object({
     department: z.string().nullable(),
   }),
   reaction: vote.optional(),
+  // True when the review belongs to the caller, so the client can offer
+  // edit/delete on it regardless of the review's moderation status.
+  isOwner: z.boolean().default(false),
 });
 
 export const CourseNoDetailSchema = CourseSchema.extend({


### PR DESCRIPTION
## Why did you create this PR

- หน้า Course Search: วิชาที่ที่นั่งเต็มดูไม่ต่างจากวิชาที่ยังว่าง
- หน้า Course Detail: ลบรีวิวได้เฉพาะสถานะ rejected ลบของตัวเองที่ pending/approved ไม่ได้

## What did you do

- ที่นั่งเต็ม (ลงทะเบียน >= ที่นั่งทั้งหมด) เปลี่ยนข้อความ "ที่นั่ง 132 / 130" เป็นสีแดง
- แสดงปุ่มลบรีวิวให้เจ้าของรีวิวทุกสถานะ (pending / confirmed / rejected) ส่วนปุ่มแก้ไขคงไว้เฉพาะ rejected
- เพิ่ม `isOwner` ใน response ของรีวิว เพื่อแยกรีวิวของตัวเองออกจากของคนอื่น (ไม่งั้นปุ่มลบจะไปโผล่บนรีวิวคนอื่นด้วย) โดยไม่ส่ง userId ของเจ้าของออกไป
- เปลี่ยน `confirm()` ของเบราว์เซอร์เป็น dialog `ConfirmDeleteReview` ตามดีไซน์ พร้อมกันกดซ้ำและ toast ตอนลบไม่สำเร็จ

## Demo

https://github.com/user-attachments/assets/c560d7e7-7462-44fe-b8ce-49b9bc156ef8

