### PR TITLE
ล็อคปีกับภาคให้ตรงกับวิชาที่เพิ่ม เวลา add วิชาแล้วต้องสร้างตารางใหม่

### DIFF
--- a/apps/cugetreg/src/lib/components/schedule-mismatch-popup.svelte
+++ b/apps/cugetreg/src/lib/components/schedule-mismatch-popup.svelte
@@ -190,6 +190,11 @@
     <CreateTimetable
       {yearOptions}
       {semesterOptions}
+      fixedTerm={{
+        academicYear: expectedYear,
+        semester: expectedSemester as 'FIRST' | 'SECOND' | 'SUMMER',
+        studyProgram: expectedProgram as 'S' | 'I' | 'T',
+      }}
       onConfirm={async (schedule: TimetableMetaData) => {
         if (
           String(schedule.academicYear) !== String(expectedYear) ||

--- a/packages/ui/src/lib/components/organisms/create-timetable/create-timetable.svelte
+++ b/packages/ui/src/lib/components/organisms/create-timetable/create-timetable.svelte
@@ -20,6 +20,12 @@
 		onConfirm?: (schedule: TimetableMetaData) => void;
 		yearOptions?: { value: string; label: string }[];
 		semesterOptions?: { value: string; label: string }[];
+		/** ล็อกระบบ/ปี/ภาคไว้ตามที่กำหนด แก้ไม่ได้ */
+		fixedTerm?: {
+			academicYear: number | string;
+			semester: 'FIRST' | 'SECOND' | 'SUMMER';
+			studyProgram: 'S' | 'I' | 'T';
+		};
 	}
 
 	let {
@@ -36,7 +42,8 @@
 			{ value: 'FIRST', label: '1' },
 			{ value: 'SECOND', label: '2' },
 			{ value: 'SUMMER', label: 'ฤดูร้อน' }
-		]
+		],
+		fixedTerm
 	}: CreateTimetableProp = $props();
 
 	interface SystemInterface {
@@ -44,16 +51,23 @@
 		label: string;
 	}
 
-	let selected_system: 'S' | 'I' | 'T' = $state('S');
+	let selected_system: 'S' | 'I' | 'T' = $state(untrack(() => fixedTerm?.studyProgram ?? 'S'));
 	const options_system: SystemInterface[] = [
 		{ value: 'S', label: 'ทวิภาค' },
 		{ value: 'T', label: 'ตรีภาค' },
 		{ value: 'I', label: 'นานาชาติ' }
 	];
 
-	let selected_year = $state(untrack(() => yearOptions[0]?.value ?? '2568'));
+	let selected_year = $state(
+		untrack(() => (fixedTerm ? String(fixedTerm.academicYear) : (yearOptions[0]?.value ?? '2568')))
+	);
 	let selected_semester: 'FIRST' | 'SECOND' | 'SUMMER' = $state(
-		untrack(() => (semesterOptions[0]?.value as 'FIRST' | 'SECOND' | 'SUMMER') ?? 'FIRST')
+		untrack(
+			() =>
+				fixedTerm?.semester ??
+				(semesterOptions[0]?.value as 'FIRST' | 'SECOND' | 'SUMMER') ??
+				'FIRST'
+		)
 	);
 
 	let tableName = $state('ตารางเรียนแสนสนุก');
@@ -88,7 +102,7 @@
 		<p class="font-orbit text-caption leading-caption text-[#898EA7]">ตั้งค่า</p>
 
 		<Select type="single" bind:value={selected_system}>
-			<SelectTrigger class="my-1 w-full" aria-label="Select system">
+			<SelectTrigger class="my-1 w-full" aria-label="Select system" disabled={!!fixedTerm}>
 				{options_system.find((x) => x.value == selected_system)?.label}
 			</SelectTrigger>
 
@@ -105,7 +119,7 @@
 
 		<div class="flex gap-2">
 			<Select type="single" bind:value={selected_year}>
-				<SelectTrigger class="my-1 flex-1" aria-label="Select year">
+				<SelectTrigger class="my-1 flex-1" aria-label="Select year" disabled={!!fixedTerm}>
 					{selected_year}
 				</SelectTrigger>
 
@@ -121,7 +135,7 @@
 			</Select>
 
 			<Select type="single" bind:value={selected_semester}>
-				<SelectTrigger class="my-1 flex-1" aria-label="Select semester">
+				<SelectTrigger class="my-1 flex-1" aria-label="Select semester" disabled={!!fixedTerm}>
 					{semesterOptions.find((x) => x.value === selected_semester)?.label}
 				</SelectTrigger>
 


### PR DESCRIPTION
## Why did you create this PR

ล็อคปีกับภาคให้ตรงกับวิชาที่เพิ่ม เวลา add วิชาแล้วต้องสร้างตารางใหม่

## What did you do

- Add `fixedTerm` prop to `CreateTimetable`. If you pass it, the system/year/semester are set from it and the dropdowns are disabled.
- Pass the course's term from `schedule-mismatch-popup` so the new timetable always matches the course.

## Demo

[

https://github.com/user-attachments/assets/b8fe0276-beea-4766-af29-c8d9391d77cd

](url)

## Checklist

- [ yes] Deploy a demo
- [ yes] Check browsers compatibility
- [ yes] Wrote coverage tests


