### PR TITLE
Feat: add closed variant to CourseCard and fix type mismatch in get course API

### DIFF
--- a/apps/core/prisma/sql/getCourseList.sql
+++ b/apps/core/prisma/sql/getCourseList.sql
@@ -307,6 +307,7 @@ section_json AS (
             json_agg(
                 json_build_object(
                     'id',          cl.id,
+                    'sectionId',   cl.section_id,
                     'type',        cl.type,
                     'dayOfWeek',   cl.day_of_week,
                     'professors',  cl.professors,
@@ -359,12 +360,11 @@ SELECT
         json_agg(
             json_build_object(
                 'id',         sj.section_id,
+                'courseId',   sj.course_id,
                 'sectionNo',  sj.section_no,
                 'closed',     sj.closed,
-                'capacity',   json_build_object(
-                    'current', sj.capacity_current,
-                    'max',     sj.capacity_max
-                ),
+                'regis',      sj.capacity_current,
+                'max',        sj.capacity_max,
                 'note',       sj.note,
                 'genEdType',  sj.gen_ed_type,
                 'classes',    sj.classes

--- a/apps/core/src/routes_define/courses.routes.ts
+++ b/apps/core/src/routes_define/courses.routes.ts
@@ -15,7 +15,7 @@ export const getCoursesRoute = createRoute({
     200: {
       content: {
         "application/json": {
-          schema: CourseResponseSchema.CourseDetailsSchema,
+          schema: CourseResponseSchema.GetCourseResponseSchema,
         },
       },
       description: "OK",

--- a/apps/core/src/services/coursesService.ts
+++ b/apps/core/src/services/coursesService.ts
@@ -10,14 +10,21 @@ import {
 } from "@/utils/enumMapper.js";
 
 import type {
-  GetCourseDetailQuerySchema,
   GetCourseQuerySchema,
   GetCourseReviewQuerySchema,
+  GetCourseDetailQuerySchema,
 } from "@cugetreg/zod-schemas/courses";
-import type { CourseReview } from "@cugetreg/zod-schemas/courses-response";
+import type {
+  CourseReview,
+  CourseDetails,
+  GetCourseResponse,
+} from "@cugetreg/zod-schemas/courses-response";
 
 //1.1 Query Course
-async function queryCourse(query: GetCourseQuerySchema, userId?: string) {
+async function queryCourse(
+  query: GetCourseQuerySchema,
+  userId?: string,
+): Promise<GetCourseResponse> {
   const {
     studyProgram,
     academicYear,
@@ -119,46 +126,49 @@ async function queryCourse(query: GetCourseQuerySchema, userId?: string) {
     reviewCounts.map((r) => [r.courseNo, r._count._all]),
   );
 
-  const data = rawResults.map((row) => ({
-    course: {
-      id: row.id,
-      studyProgram: row.study_program,
-      academicYear: row.academic_year,
-      semester: row.semester,
-      courseNo: row.course_no,
-      courseCondition: row.course_condition,
-      genEdType: row.gen_ed_type,
-      midtermStart: row.midterm_start?.toISOString() ?? null,
-      midtermEnd: row.midterm_end?.toISOString() ?? null,
-      finalStart: row.final_start?.toISOString() ?? null,
-      finalEnd: row.final_end?.toISOString() ?? null,
-      isFavorite: row.is_favorite ?? false,
-      sections: (row.sections as any[]) ?? [],
-    },
-    courseInfo: {
-      abbrName: row.abbr_name,
-      courseNameEn: row.course_name_en,
-      courseNameTh: row.course_name_th,
-      courseDescEn: row.course_desc_en,
-      courseDescTh: row.course_desc_th,
-      faculty: row.faculty ?? "",
-      department: row.department ?? "",
-      credit: row.credit ?? "",
-      creditHours: row.credit_hours ?? "",
-    },
-    stats: {
-      sectionsCount: row.sections_count ?? 0,
-      capacitySum: row.capacity_sum ?? 0,
-      remainingSum: row.remaining_sum ?? 0,
-      hasSeats: (row.remaining_sum ?? 0) > 0,
-      isClosedAll:
-        (row.sections_count ?? 0) > 0 &&
-        (row.closed_sections_count ?? 0) === (row.sections_count ?? 0),
-    },
-    reviewCount: reviewCountMap.get(row.course_no) ?? 0,
-  }));
+  const data = rawResults.map(
+    (row) =>
+      ({
+        course: {
+          id: row.id,
+          studyProgram: row.study_program,
+          academicYear: row.academic_year,
+          semester: row.semester,
+          courseNo: row.course_no,
+          courseCondition: row.course_condition,
+          genEdType: row.gen_ed_type,
+          midtermStart: row.midterm_start?.toISOString() ?? null,
+          midtermEnd: row.midterm_end?.toISOString() ?? null,
+          finalStart: row.final_start?.toISOString() ?? null,
+          finalEnd: row.final_end?.toISOString() ?? null,
+          isFavorite: row.is_favorite ?? false,
+          sections: (row.sections as any[]) ?? [],
+        },
+        courseInfo: {
+          abbrName: row.abbr_name,
+          courseNameEn: row.course_name_en,
+          courseNameTh: row.course_name_th,
+          courseDescEn: row.course_desc_en,
+          courseDescTh: row.course_desc_th,
+          faculty: row.faculty ?? "",
+          department: row.department ?? "",
+          credit: row.credit ?? "",
+          creditHours: row.credit_hours ?? "",
+        },
+        stats: {
+          sectionsCount: row.sections_count ?? 0,
+          capacitySum: row.capacity_sum ?? 0,
+          remainingSum: row.remaining_sum ?? 0,
+          hasSeats: (row.remaining_sum ?? 0) > 0,
+          isClosedAll:
+            (row.sections_count ?? 0) > 0 &&
+            (row.closed_sections_count ?? 0) === (row.sections_count ?? 0),
+        },
+        reviewCount: reviewCountMap.get(row.course_no) ?? 0,
+      }) as CourseDetails,
+  );
 
-  return { data, total };
+  return { data, total } as GetCourseResponse;
 }
 
 //1.2 get user's favorite courses

--- a/apps/core/src/services/coursesService.ts
+++ b/apps/core/src/services/coursesService.ts
@@ -120,7 +120,10 @@ async function queryCourse(
   const reviewCounts = await prisma.review.groupBy({
     by: ["courseNo"],
     _count: { _all: true },
-    where: { courseNo: { in: courseNos } },
+    where: {
+      courseNo: { in: courseNos },
+      status: ReviewStatus.APPROVED,
+    },
   });
   const reviewCountMap = new Map(
     reviewCounts.map((r) => [r.courseNo, r._count._all]),

--- a/apps/core/src/services/coursesService.ts
+++ b/apps/core/src/services/coursesService.ts
@@ -150,7 +150,7 @@ async function queryCourse(
           courseNameTh: row.course_name_th,
           courseDescEn: row.course_desc_en,
           courseDescTh: row.course_desc_th,
-          faculty: row.faculty ?? "",
+          faculty: row.faculty,
           department: row.department ?? "",
           credit: row.credit ?? "",
           creditHours: row.credit_hours ?? "",

--- a/apps/core/src/services/coursesService.ts
+++ b/apps/core/src/services/coursesService.ts
@@ -10,13 +10,13 @@ import {
 } from "@/utils/enumMapper.js";
 
 import type {
+  GetCourseDetailQuerySchema,
   GetCourseQuerySchema,
   GetCourseReviewQuerySchema,
-  GetCourseDetailQuerySchema,
 } from "@cugetreg/zod-schemas/courses";
 import type {
-  CourseReview,
   CourseDetails,
+  CourseReview,
   GetCourseResponse,
 } from "@cugetreg/zod-schemas/courses-response";
 

--- a/apps/cugetreg/src/lib/home/course-results.svelte.ts
+++ b/apps/cugetreg/src/lib/home/course-results.svelte.ts
@@ -3,7 +3,13 @@ import { api } from '$lib/api';
 import { isCancel } from 'axios';
 import { SvelteSet, SvelteURLSearchParams } from 'svelte/reactivity';
 
-import type { Semester, SortBy, StudyProgram } from '@cugetreg/zod-schemas';
+import type {
+  CourseDetails,
+  GetCourseResponse,
+  Semester,
+  SortBy,
+  StudyProgram,
+} from '@cugetreg/zod-schemas';
 
 export interface CourseQuery {
   academicYear: number;
@@ -24,37 +30,26 @@ export interface CourseQuery {
   favorite: boolean;
 }
 
-interface CourseResponse {
-  data?: unknown[];
-  total?: number;
-}
-
-interface CourseResultsOptions<T> {
+interface CourseResultsOptions {
   limit?: number;
-  mapCourse: (course: unknown) => T;
-  getKey: (course: T) => string;
 }
 
-export class CourseResults<T> {
-  courses = $state.raw<T[]>([]);
+export class CourseResults {
+  courses = $state.raw<CourseDetails[]>([]);
   isLoading = $state(false);
   hasMore = $state(true);
   totalResults = $state(0);
   error = $state<unknown>();
 
   readonly #limit: number;
-  readonly #mapCourse: (course: unknown) => T;
-  readonly #getKey: (course: T) => string;
 
   #query?: CourseQuery;
   #offset = 0;
   #generation = 0;
   #controller?: AbortController;
 
-  constructor({ limit = 20, mapCourse, getKey }: CourseResultsOptions<T>) {
+  constructor({ limit = 20 }: CourseResultsOptions = {}) {
     this.#limit = limit;
-    this.#mapCourse = mapCourse;
-    this.#getKey = getKey;
   }
 
   reset(query: CourseQuery) {
@@ -96,7 +91,7 @@ export class CourseResults<T> {
 
     try {
       const params = this.#createParams(query, requestedOffset);
-      const response = await api.get<CourseResponse>('/courses', {
+      const response = await api.get<GetCourseResponse>('/courses', {
         params,
         signal: controller.signal,
       });
@@ -106,21 +101,22 @@ export class CourseResults<T> {
       }
 
       const data = response.data.data ?? [];
-      const mapped = data.map(this.#mapCourse);
 
       this.totalResults = response.data.total ?? 0;
       this.#offset = requestedOffset + data.length;
       this.hasMore = data.length === this.#limit;
 
       if (reset) {
-        this.courses = mapped;
+        this.courses = data;
         return;
       }
 
-      const existingKeys = new SvelteSet(this.courses.map(this.#getKey));
+      const existingKeys = new SvelteSet(
+        this.courses.map((course) => course.course.id),
+      );
       this.courses = [
         ...this.courses,
-        ...mapped.filter((course) => !existingKeys.has(this.#getKey(course))),
+        ...data.filter((course) => !existingKeys.has(course.course.id)),
       ];
     } catch (error) {
       if (isCancel(error)) return;

--- a/apps/cugetreg/src/lib/home/course-results.svelte.ts
+++ b/apps/cugetreg/src/lib/home/course-results.svelte.ts
@@ -4,12 +4,13 @@ import { isCancel } from 'axios';
 import { SvelteSet, SvelteURLSearchParams } from 'svelte/reactivity';
 
 import type {
-  CourseDetails,
   GetCourseResponse,
   Semester,
   SortBy,
   StudyProgram,
 } from '@cugetreg/zod-schemas';
+
+import { type HomeCourse, mapCourse } from './home-course';
 
 export interface CourseQuery {
   academicYear: number;
@@ -35,7 +36,7 @@ interface CourseResultsOptions {
 }
 
 export class CourseResults {
-  courses = $state.raw<CourseDetails[]>([]);
+  courses = $state.raw<HomeCourse[]>([]);
   isLoading = $state(false);
   hasMore = $state(true);
   totalResults = $state(0);
@@ -101,13 +102,14 @@ export class CourseResults {
       }
 
       const data = response.data.data ?? [];
+      const mapped = data.map(mapCourse);
 
       this.totalResults = response.data.total ?? 0;
       this.#offset = requestedOffset + data.length;
       this.hasMore = data.length === this.#limit;
 
       if (reset) {
-        this.courses = data;
+        this.courses = mapped;
         return;
       }
 
@@ -116,7 +118,7 @@ export class CourseResults {
       );
       this.courses = [
         ...this.courses,
-        ...data.filter((course) => !existingKeys.has(course.course.id)),
+        ...mapped.filter((course) => !existingKeys.has(course.course.id)),
       ];
     } catch (error) {
       if (isCancel(error)) return;

--- a/apps/cugetreg/src/lib/home/home-course.ts
+++ b/apps/cugetreg/src/lib/home/home-course.ts
@@ -1,0 +1,51 @@
+import { normalizeDayMapper } from '$lib/mapper';
+
+import type { Course as CourseCardCourse } from '@cugetreg/ui/molecules/course-card';
+import type { Day } from '@cugetreg/utils/types';
+import type { CourseDetails } from '@cugetreg/zod-schemas';
+
+export interface HomeCourse {
+  recommended: boolean;
+  course: CourseDetails['course'] &
+    CourseCardCourse & {
+      courseInfo: CourseDetails['courseInfo'];
+      isFavorite: boolean;
+      closed: boolean;
+    };
+}
+
+export function mapCourse(item: CourseDetails): HomeCourse {
+  const { course, courseInfo, reviewCount, stats } = item;
+  const days = Array.from(
+    new Set(
+      course.sections
+        .flatMap((section) =>
+          section.classes.map((courseClass) => courseClass.dayOfWeek),
+        )
+        .map(normalizeDayMapper)
+        .filter((day: Day | undefined): day is Day => Boolean(day)),
+    ),
+  );
+
+  return {
+    recommended: false,
+    course: {
+      ...course,
+      courseInfo,
+      code: course.courseNo,
+      name:
+        courseInfo.abbrName ||
+        courseInfo.courseNameEn ||
+        courseInfo.courseNameTh ||
+        '-',
+      credit: Number(courseInfo.credit) || 0,
+      maxseat: stats.capacitySum,
+      seat: stats.capacitySum - stats.remainingSum,
+      gened: course.genEdType === 'NO' ? [] : [course.genEdType],
+      review: reviewCount,
+      days,
+      isFavorite: course.isFavorite ?? false,
+      closed: stats.isClosedAll,
+    },
+  };
+}

--- a/apps/cugetreg/src/routes/Home.svelte
+++ b/apps/cugetreg/src/routes/Home.svelte
@@ -8,13 +8,10 @@
   import ScheduleMismatchPopup from '$lib/components/schedule-mismatch-popup.svelte';
   import SelectedCourse from '$lib/components/selected-course.svelte';
   import { CourseResults } from '$lib/home/course-results.svelte';
+  import type { HomeCourse } from '$lib/home/home-course';
   import { createHomeUrlSync } from '$lib/home/home-url-sync.svelte';
   import { infiniteScroll } from '$lib/home/infinite-scroll';
-  import {
-    normalizeDayMapper,
-    sortByMapper,
-    studyProgramMapper,
-  } from '$lib/mapper';
+  import { sortByMapper, studyProgramMapper } from '$lib/mapper';
   import {
     getSemesterDisplayOptions,
     SEMESTER_LABEL_LONG,
@@ -55,9 +52,7 @@
   import { Filter as FilterBar } from '@cugetreg/ui/organisms/filter-bar';
   import { Footer } from '@cugetreg/ui/organisms/footer';
   import * as Sidebar from '@cugetreg/ui/organisms/sidebar';
-  import type { Day } from '@cugetreg/utils/types';
   import {
-    type CourseDetails,
     type Semester,
     type SortBy,
     type StudyProgram,
@@ -192,44 +187,6 @@
     },
   ];
 
-  function mapCourse(item: CourseDetails) {
-    const { course: c, courseInfo: ci, reviewCount } = item;
-
-    const totalMaxSeat = item.stats?.capacitySum || 0;
-    const totalCurrentSeat =
-      (item.stats?.capacitySum || 0) - (item.stats?.remainingSum || 0);
-
-    const allDays = c.sections.flatMap((section) =>
-      section.classes.map((courseClass) => courseClass.dayOfWeek),
-    );
-
-    const validDays = Array.from(
-      new Set(
-        allDays
-          .map(normalizeDayMapper)
-          .filter((d: Day | undefined): d is Day => Boolean(d)),
-      ),
-    );
-
-    return {
-      recommended: false,
-      course: {
-        ...c,
-        courseInfo: ci,
-        code: c.courseNo,
-        name: ci.abbrName || ci.courseNameEn || ci.courseNameTh || '-',
-        credit: Number(ci.credit) || 0,
-        maxseat: totalMaxSeat,
-        seat: totalCurrentSeat,
-        gened: c.genEdType === 'NO' ? [] : [c.genEdType],
-        review: reviewCount || 0,
-        days: validDays,
-        isFavorite: c.isFavorite ?? false,
-        closed: item.stats.isClosedAll,
-      },
-    };
-  }
-
   async function fetchLastUpdated(
     studyProgramParam: StudyProgram,
     academicYear: number,
@@ -257,7 +214,7 @@
   }
 
   const courseResults = new CourseResults();
-  const courses = $derived(courseResults.courses.map(mapCourse));
+  const courses = $derived(courseResults.courses);
   const isLoading = $derived(courseResults.isLoading);
   const hasMore = $derived(courseResults.hasMore);
   const totalResults = $derived(courseResults.totalResults);
@@ -309,13 +266,13 @@
 
   function setFavorite(courseCode: string, isFavorite: boolean) {
     courseResults.courses = courseResults.courses.map((item) =>
-      item.course.courseNo === courseCode
+      item.course.code === courseCode
         ? { ...item, course: { ...item.course, isFavorite } }
         : item,
     );
   }
 
-  async function handleToggleFavorite(courseItem: any) {
+  async function handleToggleFavorite(courseItem: HomeCourse) {
     if (!$session.data) {
       loginPopupState.show = true;
       return;
@@ -396,7 +353,7 @@
     return isYearMismatch || isSemesterMismatch || isProgramMismatch;
   }
 
-  function handleToggleCourse(courseItem: any) {
+  function handleToggleCourse(courseItem: HomeCourse) {
     if (!$session.data) {
       loginPopupState.show = true;
       return;
@@ -417,7 +374,7 @@
         };
       } else {
         const firstAvailableSection =
-          sections.find((sec: any) => !sec.closed) || sections[0];
+          sections.find((section) => !section.closed) || sections[0];
         if (firstAvailableSection) {
           pendingCourse = {
             courseNo: code,
@@ -435,7 +392,7 @@
         return;
       }
       const firstAvailableSection =
-        sections.find((sec: any) => !sec.closed) || sections[0];
+        sections.find((section) => !section.closed) || sections[0];
       if (firstAvailableSection) {
         addCourse(code, firstAvailableSection.sectionNo);
       }
@@ -445,7 +402,7 @@
     }
   }
 
-  function handleSelectSection(courseItem: any, sectionNo: string) {
+  function handleSelectSection(courseItem: HomeCourse, sectionNo: string) {
     const { code } = courseItem.course;
     localSelectedSections[code] = Number(sectionNo);
 
@@ -494,10 +451,10 @@
     }
   }
 
-  function getSectionOptions(courseItem: any) {
-    return (courseItem.course.sections ?? []).map((sec: any) => ({
-      value: String(sec.sectionNo),
-      label: `เซค ${sec.sectionNo}`,
+  function getSectionOptions(courseItem: HomeCourse) {
+    return courseItem.course.sections.map((section) => ({
+      value: String(section.sectionNo),
+      label: `เซค ${section.sectionNo}`,
     }));
   }
 

--- a/apps/cugetreg/src/routes/Home.svelte
+++ b/apps/cugetreg/src/routes/Home.svelte
@@ -12,7 +12,6 @@
   import { infiniteScroll } from '$lib/home/infinite-scroll';
   import {
     normalizeDayMapper,
-    normalizeGenedMapper,
     sortByMapper,
     studyProgramMapper,
   } from '$lib/mapper';
@@ -58,6 +57,7 @@
   import * as Sidebar from '@cugetreg/ui/organisms/sidebar';
   import type { Day } from '@cugetreg/utils/types';
   import {
+    type CourseDetails,
     type Semester,
     type SortBy,
     type StudyProgram,
@@ -192,15 +192,15 @@
     },
   ];
 
-  function mapCourse(item: any) {
+  function mapCourse(item: CourseDetails) {
     const { course: c, courseInfo: ci, reviewCount } = item;
 
     const totalMaxSeat = item.stats?.capacitySum || 0;
     const totalCurrentSeat =
       (item.stats?.capacitySum || 0) - (item.stats?.remainingSum || 0);
 
-    const allDays = (c.sections ?? []).flatMap((s: any) =>
-      (s.classes ?? []).map((cl: any) => cl.dayOfWeek),
+    const allDays = c.sections.flatMap((section) =>
+      section.classes.map((courseClass) => courseClass.dayOfWeek),
     );
 
     const validDays = Array.from(
@@ -221,12 +221,11 @@
         credit: Number(ci.credit) || 0,
         maxseat: totalMaxSeat,
         seat: totalCurrentSeat,
-        gened: normalizeGenedMapper(c.genEdType),
+        gened: c.genEdType === 'NO' ? [] : [c.genEdType],
         review: reviewCount || 0,
-        rating: item.rating || 0,
         days: validDays,
-        gradingType: ci.gradingType,
         isFavorite: c.isFavorite ?? false,
+        closed: item.stats.isClosedAll,
       },
     };
   }
@@ -257,11 +256,8 @@
     lastUpdatedLabel = `วันที่ ${dd}/${mm}/${buddhistYear}  เวลา ${hh}.${min} น.`;
   }
 
-  const courseResults = new CourseResults({
-    mapCourse,
-    getKey: (item) => item.course.code,
-  });
-  const courses = $derived(courseResults.courses);
+  const courseResults = new CourseResults();
+  const courses = $derived(courseResults.courses.map(mapCourse));
   const isLoading = $derived(courseResults.isLoading);
   const hasMore = $derived(courseResults.hasMore);
   const totalResults = $derived(courseResults.totalResults);
@@ -313,7 +309,7 @@
 
   function setFavorite(courseCode: string, isFavorite: boolean) {
     courseResults.courses = courseResults.courses.map((item) =>
-      item.course.code === courseCode
+      item.course.courseNo === courseCode
         ? { ...item, course: { ...item.course, isFavorite } }
         : item,
     );
@@ -897,6 +893,7 @@
                   onToggleFavorite={() => handleToggleFavorite(item)}
                   class="w-full max-w-full md:w-full"
                   courseUrl={`/course-page/${item.course.code}?${params.toString()}`}
+                  closed={item.course.closed}
                 />
               {/each}
 

--- a/packages/ui/src/lib/components/molecules/course-card/course-card.stories.svelte
+++ b/packages/ui/src/lib/components/molecules/course-card/course-card.stories.svelte
@@ -17,6 +17,9 @@
 			favorite: {
 				control: 'boolean'
 			},
+			closed: {
+				control: 'boolean'
+			},
 			onButtonClick: {
 				action: 'onButtonClick'
 			},
@@ -33,7 +36,8 @@
 					seat: 24,
 					maxseat: 305,
 					review: 14,
-					days: ['MO', 'TU', 'WE']
+					days: ['MO', 'TU', 'WE'],
+					closed: false
 				}
 			}
 		}
@@ -106,5 +110,22 @@
 			review: 0,
 			days: ['MO', 'WE']
 		}
+	}}
+/>
+
+<Story
+	name="Closed"
+	args={{
+		course: {
+			code: '2109101',
+			name: 'ENG MATERIALS',
+			credit: 3,
+			gened: [],
+			seat: 132,
+			maxseat: 130,
+			review: 0,
+			days: ['MO', 'WE']
+		},
+		closed: true
 	}}
 />

--- a/packages/ui/src/lib/components/molecules/course-card/course-card.svelte
+++ b/packages/ui/src/lib/components/molecules/course-card/course-card.svelte
@@ -26,6 +26,7 @@
 		favorite?: boolean;
 		showFavorite?: boolean;
 		onToggleFavorite?: () => void;
+		closed?: boolean;
 		[key: string]: unknown;
 	}
 
@@ -42,6 +43,7 @@
 		courseUrl = '',
 		favorite = $bindable(false),
 		showFavorite = true,
+		closed = false,
 		onToggleFavorite,
 		...rest
 	}: Props = $props();
@@ -102,9 +104,15 @@
 		<div class="text-caption flex flex-row items-center font-normal text-neutral-400">
 			<span>{course?.credit} หน่วยกิต</span>
 			<Dot color="#EDEDF1" size="16" />
-			<span class={isSeatFull ? 'text-red-500' : undefined}
-				>ที่นั่ง {course?.seat} / {course?.maxseat}</span
-			>
+
+			{#if closed}
+				<span class="text-red-500">ปิด</span>
+			{:else}
+				<span class={isSeatFull ? 'text-red-500' : undefined}
+					>ที่นั่ง {course?.seat} / {course?.maxseat}</span
+				>
+			{/if}
+
 			<Dot color="#EDEDF1" size="16" />
 			<span>{course?.review} รีวิว</span>
 		</div>
@@ -179,7 +187,7 @@
 		{#if showFavorite}
 			<button
 				type="button"
-				aria-label={favorite ? 'นำออกจากวิชาที่ถูกใจ' : 'เพิ่มเป็นวิชาที่ถูกใจ'}
+				aria-label={favorite ? 'นำออกจากวิชถูกใจ' : 'เพิ่มเป็นวิชาที่ถูกใจ'}
 				aria-pressed={favorite}
 				onclick={onFavoriteClick}
 				class="flex size-9 shrink-0 cursor-pointer items-center justify-center rounded-full transition-colors hover:bg-blue-300/40"

--- a/packages/ui/src/lib/components/molecules/course-card/course-card.svelte
+++ b/packages/ui/src/lib/components/molecules/course-card/course-card.svelte
@@ -116,7 +116,7 @@
 			<Dot color="#EDEDF1" size="16" />
 			<span>{course?.review} รีวิว</span>
 		</div>
-		<div class="flex gap-2">
+		<div class="flex min-h-6.5 gap-2">
 			{#each course?.days ?? [] as day (day)}
 				<DayChip {day} />
 			{/each}

--- a/packages/ui/src/lib/components/molecules/section-table/section-table.svelte
+++ b/packages/ui/src/lib/components/molecules/section-table/section-table.svelte
@@ -27,7 +27,7 @@
 	}: Props = $props();
 
 	const getSeatColor = (value: string) => {
-		if (value === 'ปิด') return 'bg-[#EDEDF1] text-[#6F7593]';
+		if (value === 'ปิด') return 'bg-surface-container-highest text-white';
 		if (value.includes('/')) {
 			const [taken, total] = value.split('/').map((n) => parseInt(n.trim()));
 			if (taken < total) return 'bg-[#D1FEB6] text-[#4B991C]';

--- a/packages/zod-schemas/courses.response.schema.ts
+++ b/packages/zod-schemas/courses.response.schema.ts
@@ -79,8 +79,16 @@ export const CourseDetailsSchema = z.object({
   course: CourseSchema,
   courseInfo: CourseInfoSchema,
   stats: StatsSchema,
-  fitMySchedule: z.boolean(),
+  reviewCount: z.number().int().nonnegative(),
 });
+
+export const GetCourseResponseSchema = z.object({
+  data: z.array(CourseDetailsSchema),
+  total: z.number().int().nonnegative(),
+});
+
+export type CourseDetails = z.infer<typeof CourseDetailsSchema>;
+export type GetCourseResponse = z.infer<typeof GetCourseResponseSchema>;
 
 export const CourseReview = z.object({
   id: z.string(),


### PR DESCRIPTION
## Why did you create this PR

- Add closed "ปิด" when the all section is closed (already provided by the API as `isClosedAll`
- Fix typing discrepancy between GET /courses , zod schema and SQL query. 

## What did you do

- Added closed variant to `CourseCard`
- Fixed naming and typing discrepancy between GET /courses API and raw SQL query. Specifically, the section data.
- Refactor zod schema for GET /courses as they are mismatched.

## Demo

<img width="1389" height="853" alt="image" src="https://github.com/user-attachments/assets/46085773-5a57-4d14-8ce2-bf10768c160e" />

<img width="1238" height="243" alt="image" src="https://github.com/user-attachments/assets/1276d3ef-cb44-457f-bccf-6cbbd996318b" />
