### PR TITLE
search รหัสวิชา ควรทำเปน LIKE% แทน %LIKE%

### DIFF
--- a/apps/core/prisma/sql/getCourseList.sql
+++ b/apps/core/prisma/sql/getCourseList.sql
@@ -20,6 +20,7 @@
 -- @param {Decimal} $17:credit? Optional exact credit
 -- @param {Boolean} $18:favorite? Optional when true, select user's favorite courses
 -- @param {String} $19:userId? Optional , required when get user's favorite courses
+-- @param {String} $20:qPrefix? Optional course_no prefix search (caller wraps with trailing %, e.g. 'query%')
 
 -- Perf note: LIMIT/OFFSET are applied in `ranked_courses` (Stage A, narrow),
 -- before the expensive per-class JSON aggregation in `section_json` (Stage B).
@@ -115,11 +116,11 @@ matching_sections AS (
              OR c.course_condition = ''
              OR c.course_condition = '-')
 
-        -- Text search: course_no, abbr_name, names, OR professor name
+        -- Text search: course_no (prefix match), abbr_name, names, OR professor name (substring match)
         -- (professor search is per-class; sections without classes won't match via this path)
         AND (
             $8::text IS NULL
-            OR c.course_no ILIKE $8
+            OR c.course_no ILIKE $20
             OR ci.abbr_name ILIKE $8
             OR ci.course_name_en ILIKE $8
             OR ci.course_name_th ILIKE $8

--- a/apps/core/src/services/coursesService.ts
+++ b/apps/core/src/services/coursesService.ts
@@ -100,6 +100,7 @@ async function queryCourse(query: GetCourseQuerySchema, userId?: string) {
       credit ?? null,
       favorite ?? null,
       userId ?? null,
+      q ? `${q}%` : null,
     ),
   );
 


### PR DESCRIPTION
## Why did you create this PR

search รหัสวิชา ควรทำเปน LIKE% แทน %LIKE%

## What did you do

fix search bar for course_no by only prefix
(c.course_no ILIKE $20)

## Demo
https://github.com/user-attachments/assets/0e43bca8-2823-4287-94c3-336fdce9ba4c
## Checklist

- [x] Deploy a demo
- [x] Check browsers compatibility
- [x] Wrote coverage tests

<!--
## Related links
-
-->
