### PR TITLE
Fix: Mobile can't click dropdown

### DIFF
--- a/packages/ui/src/lib/components/organisms/filter-bar/filter.svelte
+++ b/packages/ui/src/lib/components/organisms/filter-bar/filter.svelte
@@ -171,7 +171,7 @@
 					</Select.Trigger>
 				</div>
 				<Select.Content
-					class="border-surface-container bg-surface max-h-[200px] rounded-lg border shadow-[0_4px_15px_rgba(0,0,0,0.1)]"
+					class="border-surface-container bg-surface z-[110] max-h-[200px] rounded-lg border shadow-[0_4px_15px_rgba(0,0,0,0.1)]"
 					role="listbox"
 				>
 					<Select.Group>
@@ -227,7 +227,7 @@
 					</Select.Trigger>
 				</div>
 				<Select.Content
-					class="border-surface-container bg-surface max-h-[200px] rounded-lg border shadow-[0_4px_15px_rgba(0,0,0,0.1)]"
+					class="border-surface-container bg-surface z-[110] max-h-[200px] rounded-lg border shadow-[0_4px_15px_rgba(0,0,0,0.1)]"
 					role="listbox"
 				>
 					<Select.Group>
@@ -284,7 +284,7 @@
 					</Select.Trigger>
 				</div>
 				<Select.Content
-					class="border-surface-container bg-surface max-h-[200px] rounded-lg border shadow-[0_4px_15px_rgba(0,0,0,0.1)]"
+					class="border-surface-container bg-surface z-[110] max-h-[200px] rounded-lg border shadow-[0_4px_15px_rgba(0,0,0,0.1)]"
 					role="listbox"
 				>
 					<Select.Group>


### PR DESCRIPTION
## Why did you create this PR

- Fixed #1120

## What did you do

- Change Z index of dropdown to not get covered by its own modal base.

